### PR TITLE
CLI: list labels and improve doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,24 @@
 > aggregate google scholar email alerts by paper
 
 Simplifies scientific paper discovery by aggregating all unread emails under
-Gmail label from Google Scholar, grouping papers by title and formating in Markdown.
+a Gmail label from the Google Scholar alerts, grouping papers by title and producing a report in Markdown.
 
 # Workflow
 
  1. Search on Google Scholar for a paper of author
  2. Create an Alert (for citations, new or similar publications)
- 3. Create a GMail filter, moving all such emails under a dedicated Label
- 4. Run this tool to get a Markdown digest of all the paper from unread emails
+ 3. Create a GMail filter, moving all those emails under a dedicated Label
+ 4. Run this tool to get an aggregated Markdown report of all the paper from all unread emails
 
 # Run
 
-`go run main.go [-l <your-label>]`
+To find your specific label name:
+
+`go run main.go -labels`
+
+To generate the report:
+
+`go run main.go -l <your-label-name>`
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,28 @@ a Gmail label from the Google Scholar alerts, grouping papers by title and produ
 
  1. Search on Google Scholar for a paper of author
  2. Create an Alert (for citations, new or similar publications)
- 3. Create a GMail filter, moving all those emails under a dedicated Label
+ 3. Create a Gmail filter, moving all those emails under a dedicated Label
  4. Run this tool to get an aggregated Markdown report of all the paper from all unread emails
+
+# Install
+
+Either build a `scholar-alert-digest` binary and put it under `$GOPATH/bin` with:
+
+```
+cd "$(mktemp -d)" && go mod init scholar-alert-digest  && go get github.com/bzz/scholar-alert-digest
+```
+
+Or using a recent version of [`git`](https://git-scm.com) and [`go`](https://golang.org) do:
+
+```
+git clone https://github.com/bzz/scholar-alert-digest.git
+cd scholar-alert-digest
+```
+
+# Configure
+
+Turn on Gmail API & download `credentials.json` following [these steps](https://developers.google.com/gmail/api/quickstart/go#step_1_turn_on_the).
+_It will require authorizing a 'Quickstart' app to get read-only access to your Gmail account_
 
 # Run
 

--- a/README.md
+++ b/README.md
@@ -17,9 +17,16 @@ To find your specific label name:
 
 `go run main.go -labels`
 
-To generate the report:
+To generate the report, either pass the label name though CLI:
 
-`go run main.go -l <your-label-name>`
+`go run main.go -l '<your-label-name>'`
+
+Or export it as an env var:
+
+```shell
+export SAD_LABEL='<your-label-name>'
+go run main.go
+```
 
 # License
 

--- a/gmailutils/gmail.go
+++ b/gmailutils/gmail.go
@@ -39,7 +39,7 @@ import (
 func NewClient() *http.Client {
 	b, err := ioutil.ReadFile("credentials.json")
 	if err != nil {
-		log.Fatalf("Unable to read client secret file: %v", err)
+		log.Fatalf("Unable to read client secret file: %v\nPlease follow https://developers.google.com/gmail/api/quickstart/go#step_1_turn_on_the", err)
 	}
 
 	// If modifying these scopes, delete your previously saved token.json.

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,7 @@ go 1.12
 require (
 	github.com/antchfx/htmlquery v1.1.0
 	github.com/antchfx/xpath v1.1.0 // indirect
-	github.com/jehiah/cwc v0.0.0-20180823013234-bd3b7606cd22
-	golang.org/x/net v0.0.0-20191014212845-da9a3fd4c582
+	golang.org/x/net v0.0.0-20191014212845-da9a3fd4c582 // indirect
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	google.golang.org/api v0.11.0
 )

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,7 @@ github.com/antchfx/htmlquery v1.1.0/go.mod h1:MS9yksVSQXls00iXkiMqXr0J+umL/AmxXK
 github.com/antchfx/xpath v1.1.0 h1:mJTvYpiHvxNQRD4Lbfin/FodHVCHh2a5KrOFr4ZxMOI=
 github.com/antchfx/xpath v1.1.0/go.mod h1:Yee4kTMuNiPYJ7nSNorELQMr1J33uOpXDMByNYhvtNk=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
@@ -16,6 +17,7 @@ github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
+github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
@@ -25,8 +27,6 @@ github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5m
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
-github.com/jehiah/cwc v0.0.0-20180823013234-bd3b7606cd22 h1:j7CzrZ9EO1PXe1uN395xkzEy4Mj/ZuX+evzxwouatdM=
-github.com/jehiah/cwc v0.0.0-20180823013234-bd3b7606cd22/go.mod h1:/Ps9H9QoO5KsFSE5DUHb8Q1FFsteEuCJnl3D4CTjzL0=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 go.opencensus.io v0.21.0 h1:mU6zScU4U1YAFPHEHYk+3JC4SY7JxgkqS10ZOSyksNg=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
@@ -56,6 +56,7 @@ golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b h1:ag/x1USPSsqHud38I9BAC88qdNLDHHtQ4mlgQIZPPNA=
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -73,6 +74,7 @@ google.golang.org/api v0.11.0 h1:n/qM3q0/rV2F0pox7o0CvNhlPvZAo7pLbef122cbLJ0=
 google.golang.org/api v0.11.0/go.mod h1:iLdEw5Ide6rF15KTC1Kkl0iskquN2gFfn9o9XIsbkAI=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
+google.golang.org/appengine v1.5.0 h1:KxkO13IPW4Lslp2bz+KHP2E3gtFlrIGNThxkZQ3g+4c=
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=

--- a/main.go
+++ b/main.go
@@ -83,6 +83,9 @@ func main() {
 		os.Exit(0)
 	}
 
+	if envLabel, ok := os.LookupEnv("SAD_LABEL"); ok {
+		gmailLabel = &envLabel
+	}
 	var messages []*gmail.Message = gmailutils.UnreadMessagesInLabel(srv, user, *gmailLabel)
 
 	log.Printf("%d unread messages found", len(messages))

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/bzz/scholar-alert-digest/gmailutils"
 
@@ -170,7 +171,6 @@ func main() {
 			continue
 		}
 
-		// fmt.Printf(" - %s (%d)\n", subj, len(paperTitles))
 		for i, aTitle := range titles {
 			title := strings.TrimSpace(htmlquery.InnerText(aTitle))
 
@@ -186,12 +186,18 @@ func main() {
 		}
 	}
 
-	fmt.Printf("Total paper titles: %d\n", totalTitles)
-	fmt.Printf("Uniq paper titles: %d\n", len(uniqTitlesCount))
+	fmt.Printf("Date: %s\n", time.Now().Format(time.RFC3339))
+	fmt.Printf("Unread emails: %d\n", len(messages))
+	fmt.Printf("Paper titles: %d\n", totalTitles)
+	fmt.Printf("Uniq paper titles: %d\n\n", len(uniqTitlesCount))
 
-	// TODO(bzz): generate Markdown
+	// TODO(bzz):
+	//  update existing report \w checkbox state, instead of always generating a new one
+	//  mark emails as "read", when all the links are checked off
+
+	// generate Markdown report
 	for _, paper := range sortedKeys(uniqTitlesCount) {
-		fmt.Printf(" - [%s](%s) (%d)\n", paper.title, paper.url, uniqTitlesCount[paper])
+		fmt.Printf(" - [ ] [%s](%s) (%d)\n", paper.title, paper.url, uniqTitlesCount[paper])
 	}
 
 	if errCount != 0 {


### PR DESCRIPTION
Buch of improvements, including
 - `-labels` in CLI to list all actual labels
 - reading label from env var
 - updated dependencies
 - some doc cleanup, installation instructions, etc
 - checkboxes in Markdown output