### PR TITLE
Mark as read all aggregated emails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-token.json
+token*.json
 credentials.json

--- a/gmailutils/gmail.go
+++ b/gmailutils/gmail.go
@@ -74,7 +74,7 @@ func PrintAllLabels(srv *gmail.Service, user string) {
 
 	log.Printf("%d labels found", len(lablesResp.Labels))
 	for _, label := range lablesResp.Labels {
-		fmt.Printf("%s\n", label.Name)
+		fmt.Printf("%s\n", strings.ToLower(strings.ReplaceAll(label.Name, " ", "-")))
 	}
 }
 

--- a/gmailutils/token/token.go
+++ b/gmailutils/token/token.go
@@ -30,7 +30,7 @@ import (
 // FromWeb request a token from the web, then returns the retrieved token.
 func FromWeb(config *oauth2.Config) *oauth2.Token {
 	authURL := config.AuthCodeURL("state-token", oauth2.AccessTypeOffline)
-	fmt.Printf("Go to the following link in your browser then type the "+
+	fmt.Fprintf(os.Stderr, "Go to the following link in your browser then type the "+
 		"authorization code: \n%v\n", authURL)
 
 	var authCode string
@@ -59,7 +59,7 @@ func FromFile(file string) (*oauth2.Token, error) {
 
 // Save saves the token to a file path.
 func Save(path string, token *oauth2.Token) {
-	fmt.Printf("Saving credential file to: %s\n", path)
+	log.Printf("Saving credential file to: %s\n", path)
 	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		log.Fatalf("Unable to cache oauth token: %v", err)

--- a/main.go
+++ b/main.go
@@ -92,7 +92,7 @@ func main() {
 	flag.Usage = usage
 	flag.Parse()
 
-	client := gmailutils.NewClient()
+	client := gmailutils.NewClient(*markRead)
 	srv, err := gmail.New(client)
 	if err != nil {
 		log.Fatalf("Unable to create a Gmail client: %v", err)


### PR DESCRIPTION
Fixes #5 by 

 - [x] adding `-mark` CLI flag
 - [x] same label names as in Gmail on `-list`
 - [x] tweak permissions on auth process to support both R and RW tokens.

~As noted in https://github.com/bzz/scholar-alert-digest/issues/5#issuecomment-559080121 right now this fails and #7 needs to be addressed first.~
