### PR TITLE
Option to including read messages in the report

### DIFF
--- a/gmailutils/gmail.go
+++ b/gmailutils/gmail.go
@@ -91,14 +91,8 @@ func PrintAllLabels(srv *gmail.Service, user string) {
 	}
 }
 
-// UnreadMessagesInLabel returns unread messages under a given lable.
-func UnreadMessagesInLabel(srv *gmail.Service, user, labelName string) []*gmail.Message {
-	log.Printf("Searching for all unread messages under Gmail label %q", labelName)
-	return queryMessages(srv, user, fmt.Sprintf("label:%s is:unread", labelName))
-}
-
-// queryMessages returns all messages matching a query for a given user.
-func queryMessages(srv *gmail.Service, user, query string) []*gmail.Message {
+// QueryMessages returns the all messages, matching a query for a given user.
+func QueryMessages(srv *gmail.Service, user, query string) []*gmail.Message {
 	var messages []*gmail.Message
 	page := 0 // iterate pages
 	err := srv.Users.Messages.List(user).Q(query).Pages(context.TODO(), func(rm *gmail.ListMessagesResponse) error {

--- a/main.go
+++ b/main.go
@@ -41,13 +41,14 @@ const (
 	labelName  = "[-oss-]-_ml-in-se" // "[ OSS ]/_ML-in-SE" in the Web UI
 	scholarURL = "http://scholar.google.com/scholar_url?url="
 
-	usageMessage = `usage: go run [-labels] [-html] [-l <your-gmail-label>]
+	usageMessage = `usage: go run [-labels] [-html] [-mark] [-l <your-gmail-label>]
 
 Polls Gmail API for unread Google Scholar alert messaged under a given label,
 aggregates by paper title and prints a list of paper URLs in Markdown format.
 
 The -labels flag will only list all available labels for the current account.
 The -html flag will produce ouput report in HTML format.
+The -mark flag will mark all the aggregated emails as read in Gmail"
 `
 
 	mdTemplText = `# Google Scholar Alert Digest

--- a/main.go
+++ b/main.go
@@ -41,7 +41,7 @@ const (
 	labelName  = "[-oss-]-_ml-in-se" // "[ OSS ]/_ML-in-SE" in the Web UI
 	scholarURL = "http://scholar.google.com/scholar_url?url="
 
-	usageMessage = `usage: go run [-labels] [-html] [-mark] [-l <your-gmail-label>]
+	usageMessage = `usage: go run [-labels] [-html] [-mark] [-read] [-l <your-gmail-label>]
 
 Polls Gmail API for unread Google Scholar alert messaged under a given label,
 aggregates by paper title and prints a list of paper URLs in Markdown format.
@@ -49,7 +49,8 @@ aggregates by paper title and prints a list of paper URLs in Markdown format.
 The -l flag sets the Gmail label to look for (overriden by 'SAD_LABEL' env variable).
 The -labels flag will only list all available labels for the current account.
 The -html flag will produce ouput report in HTML format.
-The -mark flag will mark all the aggregated emails as read in Gmail"
+The -mark flag will mark all the aggregated emails as read in Gmail.
+The -read flag will include a new section in the report, aggregating all read emails.
 `
 
 	newMdTemplText = `# Google Scholar Alert Digest

--- a/main.go
+++ b/main.go
@@ -50,7 +50,9 @@ The -labels flag will only list all available labels for the current account.
 The -html flag will produce ouput report in HTML format.
 `
 
-	mdTemplText = `**Date**: {{.Date}}
+	mdTemplText = `# Google Scholar Alert Digest
+
+**Date**: {{.Date}}
 **Unread emails**: {{.UnreadEmails}}
 **Paper titles**: {{.TotalPapers}}
 **Uniq paper titles**: {{.UniqPapers}}
@@ -104,10 +106,7 @@ func main() {
 	}
 
 	// TODO(bzz): fetchGmailMsgsAsync returning chan *gmail.Message
-	start := time.Now()
 	var messages []*gmail.Message = fetchGmailMsgs(srv, user, *gmailLabel)
-	log.Printf("%d unread messages found (took %.0f sec)", len(messages), time.Since(start).Seconds())
-
 	errCount, titlesCount, uniqTitles := extractPapersFromMsgs(messages)
 
 	if *ouputHTML {
@@ -163,11 +162,14 @@ func generateReport(out io.Writer, tmplText string, messagesCount, titlesCount i
 
 // fetchGmailMsgs fetches all unread messages under a certain lable from Gmail.
 func fetchGmailMsgs(srv *gmail.Service, user, label string) []*gmail.Message {
+	start := time.Now()
 	if envLabel, ok := os.LookupEnv("SAD_LABEL"); ok {
 		gmailLabel = &envLabel
 	}
 
-	return gmailutils.UnreadMessagesInLabel(srv, user, label)
+	msgs := gmailutils.UnreadMessagesInLabel(srv, user, label)
+	log.Printf("%d unread messages found (took %.0f sec)", len(msgs), time.Since(start).Seconds())
+	return msgs
 }
 
 func markGmailMsgsUnread(srv *gmail.Service, user string, messages []*gmail.Message) {


### PR DESCRIPTION
Fixes #10 by adding `-read` flag that will include a new, "Archive" section of the report that includes all the read email messages.

Current implementation **does not check** that the sets of papers from _read_ and _unread_ emails are **disjunct**, so the same paper may be shown in both sections of the report.