### PR TITLE
web server instead of batch report generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ a Gmail label from the Google Scholar alerts, grouping papers by title and produ
  1. Search on Google Scholar for a paper of author
  2. Create an Alert (for citations, new or similar publications)
  3. Create a Gmail filter, moving all those emails under a dedicated Label
- 4. Run this tool to get an aggregated report (in Markdown or HTML) of all the paper from all unread emails
+ 4. Run this tool to get an aggregated report (in Markdown or HTML) of all the papers from unread emails
 
 # Install
 
@@ -20,20 +20,17 @@ either build a `scholar-alert-digest` binary and put it under `$GOPATH/bin` with
 cd "$(mktemp -d)" && go mod init scholar-alert-digest  && go get github.com/bzz/scholar-alert-digest
 ```
 
-or run from the sources by:
+or run it directly from the clone of the sources using `go` command, as described below.
 
-```
-git clone https://github.com/bzz/scholar-alert-digest.git
-cd scholar-alert-digest
-go run main.go -h
-```
+# CLI
 
-# Configure
+CLI tool for Markdown/HTML report generation.
+
+## Configure
 
 Turn on Gmail API & download `credentials.json` following [these steps](https://developers.google.com/gmail/api/quickstart/go#step_1_turn_on_the).</br>
 _That will create a new 'Quickstart' app in API console under your account and authorize it to get access to your Gmail_
 
-# Run
 
 To find your specific label name:
 
@@ -50,6 +47,7 @@ export SAD_LABEL='<your-label-name>'
 go run main.go
 ```
 
+## Run
 In order to output rendered HTML instead of the default Markdown, use
 ```
 go run main.go -html
@@ -65,6 +63,39 @@ To include read emails in the separate section of the report, do
 go run main.go -read
 ```
 
+To only aggregate the email subjects do
+```
+go run main.go -subj | uniq -c | sort -dr
+```
+
+# Web server
+Web UI that exposes basic HTML report generation to multiple concurrent users.
+
+## Configure
+It does not support same OAuth client credentials as CLI from `credentials.json`.
+It requires
+ - a different  of .
+   Create new credentials in your API project `https://console.developers.google.com/apis/credentials?project=quickstart-<NNN>`
+ - "Create credentials" -> "Web application" type
+ - Add http://localhost/login/authorized value to `Authorized redirect URIs` field
+ - Copy the `Client ID` and `Client secret`
+
+Pass in the ID and the secret as env vars e.g by
+```
+export SAD_GOOGLE_ID='<client id>'
+export SAD_GOOGLE_SECRET='<client secret>'
+```
+
+You do not need to pass the label name on the startup as it can be chosen at
+runtime at [/labels](http://localhost:8080/labels).
+
+## Run
+The basic report generation is exposed though a web server that can be started with
+```
+go run ./cmd/server
+```
+
+will start a serve on http://localhost:8080
 
 # License
 

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/bzz/scholar-alert-digest/gmailutils"
+	"github.com/bzz/scholar-alert-digest/gmailutils/token"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+	"google.golang.org/api/gmail/v1"
+)
+
+var (
+	addr     = "localhost:8080"
+	oauthCfg = &oauth2.Config{
+		// from https://console.developers.google.com/project/<your-project-id>/apiui/credential
+		ClientID:     os.Getenv("SAL_GOOGLE_ID"),
+		ClientSecret: os.Getenv("SAL_GOOGLE_SECRET"),
+		RedirectURL:  "http://localhost:8080/login/authorized",
+		Endpoint:     google.Endpoint,
+		Scopes:       []string{gmail.GmailReadonlyScope},
+	}
+)
+
+func main() {
+	// TODO(bzz):
+	//  - configure the log level, to include requests in debug
+	//  - add default req timeouts + throttling, to prevent abuse
+
+	log.Printf("starting the web server at http://%s", addr)
+	defer log.Printf("stoping the web server")
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", handleRoot)
+	mux.HandleFunc("/login", handleLogin)
+	mux.HandleFunc("/login/authorized", handleAuth)
+
+	http.ListenAndServe(addr, sessionMiddleware(mux))
+}
+
+func handleRoot(w http.ResponseWriter, r *http.Request) {
+	// get token, stored in context by middleware (from cookies)
+	tok, authorized := token.FromContext(r.Context())
+	if !authorized { // TODO(bzz): move this to middleware
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte("Not logged in: go to /login\n"))
+	}
+
+	// TOOD(bzz): if the label is known, fetch messages instead
+	// gmailutils.Fetch(srv, "me", fmt.Sprintf("label:%s is:unread", gmailLabel))
+	labels, err := gmailutils.FetchLabels(r.Context(), oauthCfg, tok)
+	if err != nil {
+		log.Printf("Unable to retrieve all labels: %v", err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	// TODO: render a template \w POST form to label selection
+	data, err := labels.MarshalJSON()
+	if err != nil {
+		log.Printf("Failed to encode labels in JSON: %v", err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	w.Write(data)
+}
+
+func handleLogin(w http.ResponseWriter, r *http.Request) {
+	// the URL which shows the Google Auth page to the user
+	url := oauthCfg.AuthCodeURL("")
+	http.Redirect(w, r, url, http.StatusFound)
+}
+
+func handleAuth(w http.ResponseWriter, r *http.Request) {
+	// get the code from URL
+	err := r.ParseForm()
+	if err != nil { // url query part is not valid
+		log.Printf("Unable to parse query string: %v", err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	// exchange the received code for a bearer token
+	code := r.FormValue("code")
+	tok, err := oauthCfg.Exchange(r.Context(), code)
+	if err != nil {
+		log.Printf("Unable to exchange the code %q for token: %v", code, err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	// save token in the session cookie
+	cookie := token.NewSessionCookie(tok)
+	log.Printf("Saving new cookie: %s", cookie.String())
+	http.SetCookie(w, cookie)
+	http.Redirect(w, r, "/", http.StatusFound)
+}
+
+// sessionMiddleware reads token from session cookie, saves it into the Context.
+func sessionMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		log.Println(r.Method, "-", r.RequestURI /*, r.Cookies()*/)
+		ctx := token.NewSessionContext(r.Context(), r.Cookies())
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -24,7 +24,7 @@ var ( // templates
 <head>
   <meta charset="UTF-8">
   <title>{{ template "title" }}</title>
-  <!-- TODO(bzz) favicon.ico -->
+  <link rel="icon" href="http://emojipedia-us.s3.dualstack.us-west-1.amazonaws.com/thumbs/240/apple/232/page-with-curl_1f4c3.png">
 </head>
 <body>{{ template "body" . }}</body>
 </html>

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -72,8 +72,8 @@ var ( // configuration
 	addr     = "localhost:8080"
 	oauthCfg = &oauth2.Config{
 		// from https://console.developers.google.com/project/<your-project-id>/apiui/credential
-		ClientID:     os.Getenv("SAL_GOOGLE_ID"),
-		ClientSecret: os.Getenv("SAL_GOOGLE_SECRET"),
+		ClientID:     os.Getenv("SAD_GOOGLE_ID"),
+		ClientSecret: os.Getenv("SAD_GOOGLE_SECRET"),
 		RedirectURL:  "http://localhost:8080/login/authorized",
 		Endpoint:     google.Endpoint,
 		Scopes:       []string{gmail.GmailReadonlyScope},

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -59,9 +59,9 @@ var ( // templates
 ## New papers
 {{ range $paper := sortedKeys .Papers }}
  - [{{ .Title }}]({{ .URL }}) ({{index $.Papers .}})
-   {{- if .Abstract.Full }}
+   {{- if .Abstract.FirstLine }}
    <details>
-     <summary>{{.Abstract.FirstLine}}</summary>{{.Abstract.RestLines}}
+     <summary>{{.Abstract.FirstLine}}</summary>{{.Abstract.Rest}}
    </details>
    {{ end }}
 {{ end }}
@@ -136,7 +136,11 @@ func handleRoot(w http.ResponseWriter, r *http.Request) {
 
 	htmlTemplText := `<!DOCTYPE html>
 	<html lang="en">
-	  <head><meta charset="UTF-8"></head>
+	  <head>
+		<meta charset="UTF-8">
+		<link rel="icon" href="http://emojipedia-us.s3.dualstack.us-west-1.amazonaws.com/thumbs/240/apple/232/page-with-curl_1f4c3.png">
+		<title>Scholar Alert Digest</title>
+	  </head>
 	  <body>%s</body>
 	</html>
 	`

--- a/gmailutils/gmail.go
+++ b/gmailutils/gmail.go
@@ -129,6 +129,7 @@ func Fetch(ctx context.Context, srv *gmail.Service, user, query string) ([]*gmai
 }
 
 // QueryMessages returns the all messages, matching a query for a given user.
+// TODO(bzz): rename to query+fetch, merge better loggin from subject branch
 func QueryMessages(ctx context.Context, srv *gmail.Service, user, query string) ([]*gmail.Message, error) {
 	var messages []*gmail.Message
 	page := 0 // iterate pages

--- a/gmailutils/gmail.go
+++ b/gmailutils/gmail.go
@@ -94,23 +94,23 @@ func FetchLabels(ctx context.Context, oauthCfg *oauth2.Config, token *oauth2.Tok
 	// Unable to retrieve all labels: Get https://www.googleapis.com/gmail/v1/users/me/labels?alt=json&prettyPrint=false: oauth2: token expired and refresh token is not set
 
 	// fetch from Gmail
-	lablesResp, err := srv.Users.Labels.List("me").Do()
+	labelsResp, err := srv.Users.Labels.List("me").Do()
 	if err != nil {
 		return nil, err
 	}
-	return lablesResp, nil
+	return labelsResp, nil
 }
 
 // PrintAllLabels prints all labels for a given user.
 func PrintAllLabels(srv *gmail.Service, user string) {
 	log.Printf("Listing all Gmail labels")
-	lablesResp, err := srv.Users.Labels.List(user).Do()
+	labelsResp, err := srv.Users.Labels.List(user).Do()
 	if err != nil {
 		log.Fatalf("Unable to retrieve all labels: %v", err)
 	}
 
-	log.Printf("%d labels found", len(lablesResp.Labels))
-	for _, label := range lablesResp.Labels {
+	log.Printf("%d labels found", len(labelsResp.Labels))
+	for _, label := range labelsResp.Labels {
 		fmt.Printf("%s\n", strings.ToLower(strings.ReplaceAll(label.Name, " ", "-")))
 	}
 }

--- a/gmailutils/gmail.go
+++ b/gmailutils/gmail.go
@@ -117,7 +117,7 @@ func PrintAllLabels(srv *gmail.Service, user string) {
 
 // Fetch fetches all messages matching a given query from the Gmail.
 func Fetch(ctx context.Context, srv *gmail.Service, user, query string) ([]*gmail.Message, error) {
-	log.Printf("Search and fetch messages from Gmail: %q", query)
+	log.Printf("searching and fetching messages from Gmail: %q", query)
 	start := time.Now()
 	msgs, err := QueryMessages(ctx, srv, user, query)
 	if err != nil {

--- a/gmailutils/gmail.go
+++ b/gmailutils/gmail.go
@@ -124,7 +124,7 @@ func Fetch(ctx context.Context, srv *gmail.Service, user, query string) ([]*gmai
 		// TODO(bzz): add several reties
 		return nil, err
 	}
-	log.Printf("%d messages fetcged with %q (took %.0f sec)", len(msgs), query, time.Since(start).Seconds())
+	log.Printf("%d messages fetched with %q (took %.0f sec)", len(msgs), query, time.Since(start).Seconds())
 	return msgs, nil
 }
 
@@ -134,7 +134,7 @@ func QueryMessages(ctx context.Context, srv *gmail.Service, user, query string) 
 	page := 0 // iterate pages
 
 	err := srv.Users.Messages.List(user).Q(query).Pages(ctx, func(mr *gmail.ListMessagesResponse) error {
-		log.Printf("page %d: found %d messages, fetching ...", page, len(mr.Messages)) // TODO(bzz): debug level only
+		log.Printf("search found %d messages, fetching", len(mr.Messages)) // TODO(bzz): debug level only
 		bar := pb.Full.Start(len(mr.Messages))
 		bar.SetMaxWidth(100)
 		defer bar.Finish()

--- a/gmailutils/token/token.go
+++ b/gmailutils/token/token.go
@@ -108,6 +108,7 @@ func NewSessionCookie(token *oauth2.Token) *http.Cookie {
 		Name:     string(sessionKey),
 		Value:    sessionVal,
 		Path:     "/",
+		Expires:  token.Expiry,
 		HttpOnly: true,
 	}
 }

--- a/gmailutils/token/token.go
+++ b/gmailutils/token/token.go
@@ -114,7 +114,6 @@ func NewSessionCookie(token *oauth2.Token) *http.Cookie {
 
 // NewLabelCookie returns a new cookie with the token set.
 func NewLabelCookie(label string) *http.Cookie {
-	// TODO(bzz): test with labels in on Gmail in Chinese/emoji
 	labelVal := base64.StdEncoding.EncodeToString([]byte(label))
 
 	return &http.Cookie{

--- a/main.go
+++ b/main.go
@@ -29,9 +29,7 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"net/url"
 	"os"
-	"regexp"
 	"sort"
 	"strings"
 	"text/template"
@@ -40,8 +38,8 @@ import (
 	"unicode/utf8"
 
 	"github.com/bzz/scholar-alert-digest/gmailutils"
+	"github.com/bzz/scholar-alert-digest/papers"
 
-	"github.com/antchfx/htmlquery"
 	"gitlab.com/golang-commonmark/markdown"
 	"google.golang.org/api/gmail/v1"
 )
@@ -105,8 +103,7 @@ The -subj flag will only include email subjects in the report. Usefull for pipin
 )
 
 var (
-	user             = "me"
-	scholarURLPrefix = regexp.MustCompile(`http(s)?://scholar\.google\.\p{L}+/scholar_url\?url=`)
+	user = "me"
 
 	gmailLabel = flag.String("l", labelName, "name of the Gmail label")
 	listLabels = flag.Bool("labels", false, "list all Gmail labels")
@@ -143,7 +140,11 @@ func main() {
 	}
 
 	if *onlySubj {
-		msgs := gmailutils.Fetch(srv, user, fmt.Sprintf("label:%s", *gmailLabel))
+		msgs, err := gmailutils.Fetch(context.TODO(), srv, user, fmt.Sprintf("label:%s", *gmailLabel))
+		if err != nil {
+			log.Fatal("Failed to fetch messages from Gmail: %v", err)
+		}
+
 		printSubjects(msgs)
 		os.Exit(0)
 	}
@@ -151,17 +152,17 @@ func main() {
 	// TODO(bzz): FetchAsync returning chan *gmail.Message
 	urMsgs, err := gmailutils.Fetch(context.TODO(), srv, user, fmt.Sprintf("label:%s is:unread", *gmailLabel))
 	if err != nil {
-		log.Fatal("Failed to fetch messages from Gmail")
+		log.Fatal("Failed to fetch messages from Gmail: %v", err)
 	}
-	errCnt, urTitlesCnt, urTitles := extractPapersFromMsgs(urMsgs)
+	errCnt, urTitlesCnt, urTitles := papers.ExtractPapersFromMsgs(urMsgs)
 
-	var rTitles map[paper]int
+	var rTitles map[papers.Paper]int
 	if *read {
 		rMsgs, err := gmailutils.Fetch(context.TODO(), srv, user, fmt.Sprintf("label:%s is:read", *gmailLabel))
 		if err != nil {
 			log.Fatal("Failed to fetch messages from Gmail")
 		}
-		_, _, rTitles = extractPapersFromMsgs(rMsgs)
+		_, _, rTitles = papers.ExtractPapersFromMsgs(rMsgs)
 	}
 
 	if *ouputHTML {
@@ -217,116 +218,7 @@ func splitOnDash(str string) ([]string, string) {
 	return strings.Split(str, sep), sep
 }
 
-func extractPapersFromMsgs(messages []*gmail.Message) (int, int, map[paper]int) {
-	errCount := 0
-	titlesCount := 0
-	uniqTitles := map[paper]int{}
-
-	for _, m := range messages {
-		papers, err := extractPapersFromMsg(m)
-		if err != nil {
-			errCount++
-			continue
-		}
-
-		titlesCount += len(papers)
-		for _, paper := range papers { // map title to uniqTitles
-			uniqTitles[paper]++
-		}
-	}
-
-	return errCount, titlesCount, uniqTitles
-}
-
-func extractPapersFromMsg(m *gmail.Message) ([]paper, error) {
-	subj := gmailutils.Subject(m.Payload)
-
-	body, err := gmailutils.MessageTextBody(m)
-	if err != nil {
-		e := fmt.Errorf("failed to get message text for ID %s - %s", m.Id, err)
-		return nil, e
-	}
-
-	doc, err := htmlquery.Parse(bytes.NewReader(body))
-	if err != nil {
-		e := fmt.Errorf("failed to parse HTML body of %q", subj)
-		return nil, e
-	}
-
-	// paper titles, from a single email
-	xpTitle := "//h3/a"
-	titles, err := htmlquery.QueryAll(doc, xpTitle)
-	if err != nil {
-		return nil, fmt.Errorf("title: not valid XPath expression %q", xpTitle)
-	}
-
-	// paper urls, from a single email
-	xpURL := "//h3/a/@href"
-	urls, err := htmlquery.QueryAll(doc, xpURL)
-	if err != nil {
-		return nil, fmt.Errorf("url: not valid XPath expression %q", xpURL)
-	}
-
-	if len(titles) != len(urls) {
-		e := fmt.Errorf("titles %d != %d urls in %q", len(titles), len(urls), subj)
-		return nil, e
-	}
-
-	// paper abstract
-	xpAbs := "//h3/following-sibling::div[2]"
-	abss, err := htmlquery.QueryAll(doc, xpAbs)
-	if err != nil {
-		return nil, fmt.Errorf("abstract: not valid XPath expression %q", xpAbs)
-	}
-
-	var papers []paper
-	for i, aTitle := range titles {
-		title := strings.TrimSpace(htmlquery.InnerText(aTitle))
-		abs := strings.TrimSpace(htmlquery.InnerText(abss[i]))
-
-		url, err := extractPaperURL(htmlquery.InnerText(urls[i]))
-		if err != nil {
-			log.Printf("Skipping paper %q in %q: %s", title, subj, err)
-			continue
-		}
-
-		papers = append(papers, paper{
-			title, url, abstract{
-				abs, separateFirstLine(abs)[0], separateFirstLine(abs)[1],
-			},
-		})
-	}
-	return papers, nil
-}
-
-// extractPaperURL returns an actual paper URL from the given scholar link.
-// Does not validate URL format but extracts it ad-hoc by trimming sufix/prefix.
-func extractPaperURL(scholarURL string) (string, error) {
-	// drop scholarURLPrefix
-	prefixLoc := scholarURLPrefix.FindStringIndex(scholarURL)
-	if prefixLoc == nil {
-		return "", fmt.Errorf("url %q does not have prefix %q", scholarURL, scholarURLPrefix.String())
-	}
-	longURL := scholarURL[prefixLoc[1]:]
-
-	// drop sufix (after &), if any
-	if sufix := strings.Index(longURL, "&"); sufix >= 0 {
-		longURL = longURL[:sufix]
-	}
-
-	return url.QueryUnescape(longURL)
-}
-
-func separateFirstLine(text string) []string {
-	text = strings.ReplaceAll(text, "\n", "")
-	n := 80 // TODO(bzz): utf8 whitespace-aware splitting alg capped by max N runes
-	if len(text) < n {
-		return []string{text, ""}
-	}
-	return []string{text[:n], text[n:]}
-}
-
-func generateAndPrintHTML(msgsCnt, titlesCnt int, unread, read map[paper]int) {
+func generateAndPrintHTML(msgsCnt, titlesCnt int, unread, read map[papers.Paper]int) {
 	var mdBuf bytes.Buffer
 	generateMarkdown(&mdBuf, msgsCnt, titlesCnt, unread, read)
 
@@ -334,11 +226,11 @@ func generateAndPrintHTML(msgsCnt, titlesCnt int, unread, read map[paper]int) {
 	fmt.Printf(htmlTemplText, md.RenderToString([]byte(mdBuf.String())))
 }
 
-func generateAndPrintMarkdown(msgsCnt, titlesCnt int, unread, read map[paper]int) {
+func generateAndPrintMarkdown(msgsCnt, titlesCnt int, unread, read map[papers.Paper]int) {
 	generateMarkdown(os.Stdout, msgsCnt, titlesCnt, unread, read)
 }
 
-func generateMarkdown(out io.Writer, msgsCnt, titlesCnt int, unread, read map[paper]int) {
+func generateMarkdown(out io.Writer, msgsCnt, titlesCnt int, unread, read map[papers.Paper]int) {
 	newMdReport(out, msgsCnt, titlesCnt, unread)
 	if read != nil {
 		oldMdReport(out, read)
@@ -346,23 +238,23 @@ func generateMarkdown(out io.Writer, msgsCnt, titlesCnt int, unread, read map[pa
 }
 
 // renderes newMdTemplText for new, unread papers.
-func newMdReport(out io.Writer, msgsCnt, titlesCnt int, papers map[paper]int) {
+func newMdReport(out io.Writer, msgsCnt, titlesCnt int, agrPapers map[papers.Paper]int) {
 	tmplText := newMdTemplText
 	tmpl := template.Must(template.New("unread-papers").Funcs(template.FuncMap{
-		"sortedKeys": sortedKeys,
+		"sortedKeys": papers.SortedKeys,
 	}).Parse(tmplText))
 	err := tmpl.Execute(out, struct {
 		Date         string
 		UnreadEmails int
 		TotalPapers  int
 		UniqPapers   int
-		Papers       map[paper]int
+		Papers       map[papers.Paper]int
 	}{
 		time.Now().Format(time.RFC3339),
 		msgsCnt,
 		titlesCnt,
-		len(papers),
-		papers,
+		len(agrPapers),
+		agrPapers,
 	})
 	if err != nil {
 		log.Fatalf("template %q execution failed: %s", tmplText, err)
@@ -370,12 +262,12 @@ func newMdReport(out io.Writer, msgsCnt, titlesCnt int, papers map[paper]int) {
 }
 
 // renderes oldMdTemplText for old, read papers
-func oldMdReport(out io.Writer, papers map[paper]int) {
+func oldMdReport(out io.Writer, agrPapers map[papers.Paper]int) {
 	tmplText := oldMdTemplText
 	tmpl := template.Must(template.New("read-papers").Funcs(template.FuncMap{
-		"sortedKeys": sortedKeys,
+		"sortedKeys": papers.SortedKeys,
 	}).Parse(tmplText))
-	err := tmpl.Execute(out, papers)
+	err := tmpl.Execute(out, agrPapers)
 	if err != nil {
 		log.Fatalf("template %q execution failed: %s", tmplText, err)
 	}
@@ -398,42 +290,4 @@ func markGmailMsgsUnread(srv *gmail.Service, user string, messages []*gmail.Mess
 	}
 	// TODO(bzz): move to
 	//  gmailutils.ModifyMessagesDelLabel(srv, user, messages, "UNREAD")
-}
-
-// Helpers for a Map, sorted by keys.
-// TODO(bzz): move to map.go after `go run main.go` is replaced by ./cmd/report
-type sortedMap struct {
-	m map[paper]int
-	s []paper
-}
-
-func (sm *sortedMap) Len() int           { return len(sm.m) }
-func (sm *sortedMap) Less(i, j int) bool { return sm.m[sm.s[i]] > sm.m[sm.s[j]] }
-func (sm *sortedMap) Swap(i, j int)      { sm.s[i], sm.s[j] = sm.s[j], sm.s[i] }
-
-// TODO(bzz): use a stable sort
-func sortedKeys(m map[paper]int) []paper {
-	sm := new(sortedMap)
-	sm.m = m
-	sm.s = make([]paper, len(m))
-	i := 0
-	for key := range m {
-		sm.s[i] = key
-		i++
-	}
-	sort.Sort(sm)
-	return sm.s
-}
-
-// paper is a map key, thus aggregation take into account all it's fields.
-//
-// TODO(bzz): think about aggregation only by the title, as suggested in
-// https://github.com/bzz/scholar-alert-digest/issues/12#issuecomment-562820924
-type paper struct {
-	Title, URL string
-	Abstract   abstract
-}
-
-type abstract struct {
-	Full, FirstLine, RestLines string
 }

--- a/main.go
+++ b/main.go
@@ -142,18 +142,18 @@ func main() {
 	}
 
 	if *onlySubj {
-		msgs := fetchGmail(srv, user, fmt.Sprintf("label:%s", *gmailLabel))
+		msgs := gmailutils.Fetch(srv, user, fmt.Sprintf("label:%s", *gmailLabel))
 		printSubjects(msgs)
 		os.Exit(0)
 	}
 
-	// TODO(bzz): fetchGmailAsync returning chan *gmail.Message
-	var urMsgs []*gmail.Message = fetchGmail(srv, user, fmt.Sprintf("label:%s is:unread", *gmailLabel))
+	// TODO(bzz): FetchAsync returning chan *gmail.Message
+	var urMsgs []*gmail.Message = gmailutils.Fetch(srv, user, fmt.Sprintf("label:%s is:unread", *gmailLabel))
 	errCnt, urTitlesCnt, urTitles := extractPapersFromMsgs(urMsgs)
 
 	var rTitles map[paper]int
 	if *read {
-		rMsgs := fetchGmail(srv, user, fmt.Sprintf("label:%s is:read", *gmailLabel))
+		rMsgs := gmailutils.Fetch(srv, user, fmt.Sprintf("label:%s is:read", *gmailLabel))
 		_, _, rTitles = extractPapersFromMsgs(rMsgs)
 	}
 
@@ -208,15 +208,6 @@ func splitOnDash(str string) ([]string, string) {
 	}
 	sep := fmt.Sprintf(" %s ", dash)
 	return strings.Split(str, sep), sep
-}
-
-// fetchGmail fetches all messages matching a given query from the Gmail.
-func fetchGmail(srv *gmail.Service, user, query string) []*gmail.Message {
-	log.Printf("searching Gmail messages, query: %q", query)
-	start := time.Now()
-	msgs := gmailutils.QueryMessages(srv, user, query)
-	log.Printf("got %d messages total (took %.0f sec)", len(msgs), time.Since(start).Seconds())
-	return msgs
 }
 
 func extractPapersFromMsgs(messages []*gmail.Message) (int, int, map[paper]int) {

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"flag"
 	"fmt"
 	"io"
@@ -148,12 +149,18 @@ func main() {
 	}
 
 	// TODO(bzz): FetchAsync returning chan *gmail.Message
-	var urMsgs []*gmail.Message = gmailutils.Fetch(srv, user, fmt.Sprintf("label:%s is:unread", *gmailLabel))
+	urMsgs, err := gmailutils.Fetch(context.TODO(), srv, user, fmt.Sprintf("label:%s is:unread", *gmailLabel))
+	if err != nil {
+		log.Fatal("Failed to fetch messages from Gmail")
+	}
 	errCnt, urTitlesCnt, urTitles := extractPapersFromMsgs(urMsgs)
 
 	var rTitles map[paper]int
 	if *read {
-		rMsgs := gmailutils.Fetch(srv, user, fmt.Sprintf("label:%s is:read", *gmailLabel))
+		rMsgs, err := gmailutils.Fetch(context.TODO(), srv, user, fmt.Sprintf("label:%s is:read", *gmailLabel))
+		if err != nil {
+			log.Fatal("Failed to fetch messages from Gmail")
+		}
 		_, _, rTitles = extractPapersFromMsgs(rMsgs)
 	}
 

--- a/main.go
+++ b/main.go
@@ -68,7 +68,7 @@ The -subj flag will only include email subjects in the report. Usefull for pipin
 ## New papers
 {{ range $paper := sortedKeys .Papers }}
  - [{{ .Title }}]({{ .URL }}) ({{index $.Papers .}})
-   {{- if .Abstract.Full }}
+   {{- if .Abstract.FirstLine }}
    <details>
      <summary>{{.Abstract.FirstLine}}</summary>{{.Abstract.RestLines}}
    </details>
@@ -83,9 +83,9 @@ The -subj flag will only include email subjects in the report. Usefull for pipin
 
 {{ range $paper := sortedKeys . }}
   - [{{ .Title }}]({{ .URL }})
-    {{- if .Abstract.Full }}
+    {{- if .Abstract.FirstLine }}
     <details>
-      <summary>{{.Abstract.FirstLine}}</summary>{{.Abstract.RestLines}}
+      <summary>{{.Abstract.FirstLine}}</summary>{{.Abstract.Rest}}
     </details>
     {{ end }}
 {{ end }}

--- a/main.go
+++ b/main.go
@@ -70,7 +70,7 @@ The -subj flag will only include email subjects in the report. Usefull for pipin
  - [{{ .Title }}]({{ .URL }}) ({{index $.Papers .}})
    {{- if .Abstract.FirstLine }}
    <details>
-     <summary>{{.Abstract.FirstLine}}</summary>{{.Abstract.RestLines}}
+     <summary>{{.Abstract.FirstLine}}</summary>{{.Abstract.Rest}}
    </details>
    {{ end }}
 {{ end }}

--- a/markdown/md.go
+++ b/markdown/md.go
@@ -1,0 +1,53 @@
+// Package markdown handles the Markdown generation and it's rendering to HTML.
+package markdown
+
+import (
+	"io"
+	"log"
+	"text/template"
+	"time"
+
+	"github.com/bzz/scholar-alert-digest/papers"
+)
+
+// GenerateMd generates Markdown report for unread emails and the read ones, if any.
+func GenerateMd(out io.Writer, newTmplText, oldTmplText string, msgsCnt, titlesCnt int, unread, read map[papers.Paper]int) {
+	newMdReport(out, newTmplText, msgsCnt, titlesCnt, unread)
+	if read != nil {
+		oldMdReport(out, oldTmplText, read)
+	}
+}
+
+// newMdReport renderes tmplText \w email msg stats (for new, unread papers).
+func newMdReport(out io.Writer, tmplText string, msgsCnt, titlesCnt int, agrPapers map[papers.Paper]int) {
+	tmpl := template.Must(template.New("unread-papers").Funcs(template.FuncMap{
+		"sortedKeys": papers.SortedKeys,
+	}).Parse(tmplText))
+	err := tmpl.Execute(out, struct {
+		Date         string
+		UnreadEmails int
+		TotalPapers  int
+		UniqPapers   int
+		Papers       map[papers.Paper]int
+	}{
+		time.Now().Format(time.RFC3339),
+		msgsCnt,
+		titlesCnt,
+		len(agrPapers),
+		agrPapers,
+	})
+	if err != nil {
+		log.Fatalf("template %q execution failed: %s", tmplText, err)
+	}
+}
+
+// oldMdReport renderes tmplText \wo stats (for old, read papers).
+func oldMdReport(out io.Writer, tmplText string, agrPapers map[papers.Paper]int) {
+	tmpl := template.Must(template.New("read-papers").Funcs(template.FuncMap{
+		"sortedKeys": papers.SortedKeys,
+	}).Parse(tmplText))
+	err := tmpl.Execute(out, agrPapers)
+	if err != nil {
+		log.Fatalf("template %q execution failed: %s", tmplText, err)
+	}
+}

--- a/papers/papers.go
+++ b/papers/papers.go
@@ -61,6 +61,7 @@ func SortedKeys(m map[Paper]int) []Paper {
 }
 
 // ExtractPapersFromMsgs parses the messages payloads and creates Papers.
+// TODO(bzz): rename to extract+aggregate
 func ExtractPapersFromMsgs(messages []*gmail.Message) (int, int, map[Paper]int) {
 	errCount := 0
 	titlesCount := 0
@@ -73,6 +74,7 @@ func ExtractPapersFromMsgs(messages []*gmail.Message) (int, int, map[Paper]int) 
 			continue
 		}
 
+		// aggregate
 		titlesCount += len(papers)
 		for _, paper := range papers { // map title to uniqTitles
 			uniqTitles[paper]++

--- a/papers/papers.go
+++ b/papers/papers.go
@@ -1,0 +1,169 @@
+// Package papers indes a data model and utilities for paper details extraction.
+package papers
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"net/url"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/antchfx/htmlquery"
+	"google.golang.org/api/gmail/v1"
+
+	"github.com/bzz/scholar-alert-digest/gmailutils"
+)
+
+var scholarURLPrefix = regexp.MustCompile(`http(s)?://scholar\.google\.\p{L}+/scholar_url\?url=`)
+
+// Paper is a map key, thus aggregation take into account all it's fields.
+//
+// TODO(bzz): think about aggregation only by the title, as suggested in
+// https://github.com/bzz/scholar-alert-digest/issues/12#issuecomment-562820924
+type Paper struct {
+	Title, URL string
+	Abstract   Abstract
+}
+
+// Abstract represents a view of parsed abstract.
+type Abstract struct {
+	Full, FirstLine, RestLines string
+}
+
+// Helpers for a Map, sorted by keys.
+// TODO(bzz): move to map.go after `go run main.go` is replaced by ./cmd/report
+type sortedMap struct {
+	m map[Paper]int
+	s []Paper
+}
+
+func (sm *sortedMap) Len() int           { return len(sm.m) }
+func (sm *sortedMap) Less(i, j int) bool { return sm.m[sm.s[i]] > sm.m[sm.s[j]] }
+func (sm *sortedMap) Swap(i, j int)      { sm.s[i], sm.s[j] = sm.s[j], sm.s[i] }
+
+// SortedKeys sort the given map by key.
+// TODO(bzz): use a stable sort
+func SortedKeys(m map[Paper]int) []Paper {
+	sm := new(sortedMap)
+	sm.m = m
+	sm.s = make([]Paper, len(m))
+	i := 0
+	for key := range m {
+		sm.s[i] = key
+		i++
+	}
+	sort.Sort(sm)
+	return sm.s
+}
+
+// ExtractPapersFromMsgs parses the messages payloads and creates Papers.
+func ExtractPapersFromMsgs(messages []*gmail.Message) (int, int, map[Paper]int) {
+	errCount := 0
+	titlesCount := 0
+	uniqTitles := map[Paper]int{}
+
+	for _, m := range messages {
+		papers, err := extractPapersFromMsg(m)
+		if err != nil {
+			errCount++
+			continue
+		}
+
+		titlesCount += len(papers)
+		for _, paper := range papers { // map title to uniqTitles
+			uniqTitles[paper]++
+		}
+	}
+
+	return errCount, titlesCount, uniqTitles
+}
+
+func extractPapersFromMsg(m *gmail.Message) ([]Paper, error) {
+	subj := gmailutils.Subject(m.Payload)
+
+	body, err := gmailutils.MessageTextBody(m)
+	if err != nil {
+		e := fmt.Errorf("failed to get message text for ID %s - %s", m.Id, err)
+		return nil, e
+	}
+
+	doc, err := htmlquery.Parse(bytes.NewReader(body))
+	if err != nil {
+		e := fmt.Errorf("failed to parse HTML body of %q", subj)
+		return nil, e
+	}
+
+	// paper titles, from a single email
+	xpTitle := "//h3/a"
+	titles, err := htmlquery.QueryAll(doc, xpTitle)
+	if err != nil {
+		return nil, fmt.Errorf("title: not valid XPath expression %q", xpTitle)
+	}
+
+	// paper urls, from a single email
+	xpURL := "//h3/a/@href"
+	urls, err := htmlquery.QueryAll(doc, xpURL)
+	if err != nil {
+		return nil, fmt.Errorf("url: not valid XPath expression %q", xpURL)
+	}
+
+	if len(titles) != len(urls) {
+		e := fmt.Errorf("titles %d != %d urls in %q", len(titles), len(urls), subj)
+		return nil, e
+	}
+
+	// paper abstract
+	xpAbs := "//h3/following-sibling::div[2]"
+	abss, err := htmlquery.QueryAll(doc, xpAbs)
+	if err != nil {
+		return nil, fmt.Errorf("abstract: not valid XPath expression %q", xpAbs)
+	}
+
+	var papers []Paper
+	for i, aTitle := range titles {
+		title := strings.TrimSpace(htmlquery.InnerText(aTitle))
+		abs := strings.TrimSpace(htmlquery.InnerText(abss[i]))
+
+		url, err := extractPaperURL(htmlquery.InnerText(urls[i]))
+		if err != nil {
+			log.Printf("Skipping paper %q in %q: %s", title, subj, err)
+			continue
+		}
+
+		papers = append(papers, Paper{
+			title, url, Abstract{
+				abs, separateFirstLine(abs)[0], separateFirstLine(abs)[1],
+			},
+		})
+	}
+	return papers, nil
+}
+
+// extractPaperURL returns an actual paper URL from the given scholar link.
+// Does not validate URL format but extracts it ad-hoc by trimming sufix/prefix.
+func extractPaperURL(scholarURL string) (string, error) {
+	// drop scholarURLPrefix
+	prefixLoc := scholarURLPrefix.FindStringIndex(scholarURL)
+	if prefixLoc == nil {
+		return "", fmt.Errorf("url %q does not have prefix %q", scholarURL, scholarURLPrefix.String())
+	}
+	longURL := scholarURL[prefixLoc[1]:]
+
+	// drop sufix (after &), if any
+	if sufix := strings.Index(longURL, "&"); sufix >= 0 {
+		longURL = longURL[:sufix]
+	}
+
+	return url.QueryUnescape(longURL)
+}
+
+func separateFirstLine(text string) []string {
+	text = strings.ReplaceAll(text, "\n", "")
+	n := 80 // TODO(bzz): utf8 whitespace-aware splitting alg capped by max N runes
+	if len(text) < n {
+		return []string{text, ""}
+	}
+	return []string{text[:n], text[n:]}
+}

--- a/papers/papers_test.go
+++ b/papers/papers_test.go
@@ -1,52 +1,148 @@
 package papers
 
 import (
+	"fmt"
+	"strings"
 	"testing"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // UnitTests for paper extraction.
 
 func TestScholarURLExtraction(t *testing.T) {
-	var fixtures = []struct {
+	var testCases = []struct {
+		name       string
 		scholarURL string
 		URL        string
-		toHaveErr  bool
+		hasErr     bool
 	}{
-		{ // error
-			"", "", true,
+		{
+			"error", "", "", true,
 		},
 		{
+			"regular .com",
 			"http://scholar.google.com/scholar_url?url=https://arxiv.org/pdf/1911.12863&hl=en&sa=X&d=206864271411405978&scisig=AAGBfm07fPzie7SdYtYu_zrwxV7xx4o74g&nossl=1&oi=scholaralrt&hist=KBiQzPUAAAAJ:14254687125141938744:AAGBfm10na1baTgbjiNc57Wm9bK7bSlS3g",
 			"https://arxiv.org/pdf/1911.12863", false,
 		},
-		{ // non .com
+		{
+			"non .com",
 			"http://scholar.google.ru/scholar_url?url=https://www.jstage.jst.go.jp/article/transinf/E102.D/12/E102.D_2019MPP0005/_article/-char/ja/&hl=en",
 			"https://www.jstage.jst.go.jp/article/transinf/E102.D/12/E102.D_2019MPP0005/_article/-char/ja/", false,
 		},
 		{
+			"anothe TLD, short URL",
 			"https://scholar.google.au/scholar_url?url=http://www.test.com&hl=1",
 			"http://www.test.com", false,
 		},
-		{ // single query (no &)
+		{
+			"single query (no &)",
 			"http://scholar.google.au/scholar_url?url=http://www.test.com",
 			"http://www.test.com", false,
 		},
-		{ // non-latin TLD
+		{
+			"non-latin TLD",
 			"https://scholar.google.рф/scholar_url?url=http://www.test.com&hl=1",
 			"http://www.test.com", false,
 		},
 	}
 
-	for _, expected := range fixtures {
-		actualURL, err := extractPaperURL(expected.scholarURL)
-		if expected.toHaveErr {
-			assert.Error(t, err)
-			continue
-		}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualURL, err := extractPaperURL(tc.scholarURL)
+			if tc.hasErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tc.URL, actualURL)
 
-		assert.NoError(t, err)
-		assert.Equal(t, expected.URL, actualURL)
+		})
+	}
+}
+
+var lineSplitCases = []struct {
+	text         string
+	n, lookahead int
+	first, rest  string
+}{
+	{"й", 2, 2, "й", ""},
+	{"abcd", 2, 2, "abcd", ""},
+	{"abcdef", 2, 2, "abcd", "ef"},
+	{"ab cdef", 2, 2, "ab", "cdef"},
+	{
+		"Многие методы преобразования программ (включая суперкомпиляцию и насыщение равенствами) можно сформулировать в виде набора правил переписывания графов или термов, применяемых в некотором порядке …",
+		80, 10,
+		"Многие методы преобразования программ (включая суперкомпиляцию и насыщение равенствами)",
+		"можно сформулировать в виде набора правил переписывания графов или термов, применяемых в некотором порядке …",
+	},
+}
+
+func TestAbstractFirstLine(t *testing.T) {
+	for i, f := range lineSplitCases {
+		first, rest := separateFirstLine(f.text, f.n, f.lookahead)
+		require.Equal(t, f.first, first, "case %d", i)
+		require.Equal(t, f.rest, rest, "case %d", i)
+	}
+}
+
+func BenchmarkAbstractFirstLine(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		for _, f := range lineSplitCases {
+			separateFirstLine(f.text, f.n, f.lookahead)
+		}
+	}
+}
+
+// separateFirstLineSimple is presumably more readable version of first line separation.
+//  BenchmarkAbstractFirstLine-4          	  2018 ns/op	       0 B/op	       0 allocs/op
+//  BenchmarkAbstractFirstLineSimpler-4   	  6008 ns/op	    1176 B/op	      14 allocs/op
+func separateFirstLineSimple(text string, N, lookahead int) (string, string) {
+	text = strings.ReplaceAll(text, "\n", "")
+
+	total := 0
+	var first []string
+	for _, w := range strings.Fields(text) {
+		total += utf8.RuneCountInString(w)
+		if total > N {
+			break
+		}
+		first = append(first, w)
+	}
+
+	f := strings.Join(first, " ")
+	if f == "" {
+		r := []rune(text)
+		if len(r) > N+lookahead {
+			f = string(r[:N+lookahead])
+		} else {
+			f = text
+		}
+	}
+
+	r := strings.TrimPrefix(text, f)
+	return f, strings.TrimLeftFunc(r, unicode.IsSpace)
+}
+
+func TestAbstractFirstLineSimpler(t *testing.T) {
+	for i, f := range lineSplitCases {
+		t.Run(fmt.Sprintf("case %d", i), func(*testing.T) {
+			first, rest := separateFirstLineSimple(f.text, f.n, f.lookahead)
+			require.Equal(t, f.first, first)
+			require.Equal(t, f.rest, rest)
+		})
+	}
+}
+
+func BenchmarkAbstractFirstLineSimpler(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		for _, f := range lineSplitCases {
+			separateFirstLineSimple(f.text, f.n, f.lookahead)
+		}
 	}
 }

--- a/papers/papers_test.go
+++ b/papers/papers_test.go
@@ -1,4 +1,4 @@
-package main
+package papers
 
 import (
 	"testing"
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// Unit test for the CLI utilities.
+// UnitTests for paper extraction.
 
 func TestScholarURLExtraction(t *testing.T) {
 	var fixtures = []struct {


### PR DESCRIPTION
Addresses #14 

TODOs:
 - [x] separate server binary (easier that way, offline/online could be united to single binary later)
 - [x] 3-legged Oauth2.0 flow support
 - [x] multitenancy: store session tokens per-user (in cookies)
 - [x]  multitenancy: allow to choose a label name, store it per-user
 - [x] aggregation & HTML rendering of messages
 - [x] better abstract split (unicode friendly, whitespace-aware)
 - [x] ~automatic token refresh~ automation will be added later,
           it's enough that it redirects to `/login` on token expiration now
 - [ ] ~add API fetch progress indicator~
 - [ ] ~main page rendering using `html/template`~
