### PR TITLE
Fix report duplicates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,9 +8,10 @@ require (
 	github.com/antchfx/xpath v1.1.2 // indirect
 	github.com/golang/groupcache v0.0.0-20191027212112-611e8accdfc9 // indirect
 	github.com/google/go-cmp v0.3.1 // indirect
+	github.com/stretchr/testify v1.4.0
 	gitlab.com/golang-commonmark/markdown v0.0.0-20191124021542-fffb4bed7d15
 	go.opencensus.io v0.22.2 // indirect
-	golang.org/x/net v0.0.0-20191126235420-ef20fe5d7933 // indirect
+	golang.org/x/net v0.0.0-20191126235420-ef20fe5d7933
 	golang.org/x/oauth2 v0.0.0-20191122200657-5d9234df094c
 	golang.org/x/sys v0.0.0-20191127021746-63cb32ae39b2 // indirect
 	google.golang.org/api v0.14.0

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,7 @@ github.com/antchfx/xpath v1.1.2 h1:YziPrtM0gEJBnhdUGxYcIVYXZ8FXbtbovxOi+UW/yWQ=
 github.com/antchfx/xpath v1.1.2/go.mod h1:Yee4kTMuNiPYJ7nSNorELQMr1J33uOpXDMByNYhvtNk=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
@@ -60,6 +61,7 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
@@ -70,6 +72,7 @@ github.com/russross/blackfriday v2.0.0+incompatible/go.mod h1:JO/DiYxRf+HjHt06Oy
 github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 gitlab.com/golang-commonmark/html v0.0.0-20191124015941-a22733972181 h1:K+bMSIx9A7mLES1rtG+qKduLIXq40DAzYHtb0XuCukA=
 gitlab.com/golang-commonmark/html v0.0.0-20191124015941-a22733972181/go.mod h1:dzYhVIwWCtzPAa4QP98wfB9+mzt33MSmM8wsKiMi2ow=
@@ -201,6 +204,7 @@ google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQ
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/main.go
+++ b/main.go
@@ -270,16 +270,12 @@ func extractPaperURL(scholarURL string) (string, error) {
 		longURL = longURL[:sufix]
 	}
 
-	url, err := url.QueryUnescape(longURL)
-	if err != nil {
-		return "", err
-	}
-	return url, nil
+	return url.QueryUnescape(longURL)
 }
 
 func separateFirstLine(text string) []string {
 	text = strings.ReplaceAll(text, "\n", "")
-	n := 80 // TODO(bzz): whitespace-aware splitting alg capped by max N
+	n := 80 // TODO(bzz): utf8 whitespace-aware splitting alg capped by max N runes
 	if len(text) < n {
 		return []string{text, ""}
 	}

--- a/main.go
+++ b/main.go
@@ -15,6 +15,11 @@
  */
 
 // CLI tool for aggregating unread messages in Gmail from Google Scholar Alert.
+//
+// It does so by:
+//  - fetching messages under a certian Gmail label
+//  - transforming and aggregateing them into map[paper]int
+//  - rendering a text/template with it, in Markdown or HTML
 package main
 
 import (
@@ -380,6 +385,10 @@ func sortedKeys(m map[paper]int) []paper {
 	return sm.s
 }
 
+// paper is a map key, thus aggregation take into account all it's fields.
+//
+// TODO(bzz): think about aggregation only by the title, as suggested in
+// https://github.com/bzz/scholar-alert-digest/issues/12#issuecomment-562820924
 type paper struct {
 	Title, URL string
 	Abstract   abstract

--- a/main.go
+++ b/main.go
@@ -38,8 +38,8 @@ import (
 )
 
 const (
-	labelName  = "[-oss-]-_ml-in-se" // "[ OSS ]/_ML-in-SE" in the Web UI
-	scholarURL = "http://scholar.google.com/scholar_url?url="
+	labelName        = "[-oss-]-_ml-in-se" // "[ OSS ]/_ML-in-SE" in the Web UI
+	scholarPrefixURL = "http://scholar.google.com/scholar_url?url="
 
 	usageMessage = `usage: go run [-labels] [-html] [-mark] [-read] [-l <your-gmail-label>]
 
@@ -234,8 +234,7 @@ func extractPapersFromMsg(m *gmail.Message) ([]paper, error) {
 		title := strings.TrimSpace(htmlquery.InnerText(aTitle))
 		abs := strings.TrimSpace(htmlquery.InnerText(abss[i]))
 
-		longURL := strings.TrimPrefix(htmlquery.InnerText(urls[i]), scholarURL)
-		url, err := url.QueryUnescape(longURL[:strings.Index(longURL, "&")])
+		url, err := extractPaperURL(htmlquery.InnerText(urls[i]))
 		if err != nil {
 			log.Printf("Skipping paper %q in %q: %s", title, subj, err)
 			continue
@@ -248,6 +247,15 @@ func extractPapersFromMsg(m *gmail.Message) ([]paper, error) {
 		})
 	}
 	return papers, nil
+}
+
+func extractPaperURL(scholarURL string) (string, error) {
+	longURL := strings.TrimPrefix(scholarURL, scholarPrefixURL)
+	url, err := url.QueryUnescape(longURL[:strings.Index(longURL, "&")])
+	if err != nil {
+		return "", err
+	}
+	return url, nil
 }
 
 func separateFirstLine(text string) []string {

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Unit test for the CLI utilities.
+
+func TestScholarURLExtraction(t *testing.T) {
+	var fixtures = []struct {
+		scholarURL string
+		URL        string
+	}{
+		{
+			"http://scholar.google.com/scholar_url?url=https://arxiv.org/pdf/1911.12863&hl=en&sa=X&d=206864271411405978&scisig=AAGBfm07fPzie7SdYtYu_zrwxV7xx4o74g&nossl=1&oi=scholaralrt&hist=KBiQzPUAAAAJ:14254687125141938744:AAGBfm10na1baTgbjiNc57Wm9bK7bSlS3g",
+			"https://arxiv.org/pdf/1911.12863",
+		},
+	}
+
+	for _, expected := range fixtures {
+		actualURL, err := extractPaperURL(expected.scholarURL)
+		assert.Nil(t, err)
+		assert.Equal(t, expected.URL, actualURL)
+	}
+}

--- a/utils_test.go
+++ b/utils_test.go
@@ -12,16 +12,41 @@ func TestScholarURLExtraction(t *testing.T) {
 	var fixtures = []struct {
 		scholarURL string
 		URL        string
+		toHaveErr  bool
 	}{
+		{ // error
+			"", "", true,
+		},
 		{
 			"http://scholar.google.com/scholar_url?url=https://arxiv.org/pdf/1911.12863&hl=en&sa=X&d=206864271411405978&scisig=AAGBfm07fPzie7SdYtYu_zrwxV7xx4o74g&nossl=1&oi=scholaralrt&hist=KBiQzPUAAAAJ:14254687125141938744:AAGBfm10na1baTgbjiNc57Wm9bK7bSlS3g",
-			"https://arxiv.org/pdf/1911.12863",
+			"https://arxiv.org/pdf/1911.12863", false,
+		},
+		{ // non .com
+			"http://scholar.google.ru/scholar_url?url=https://www.jstage.jst.go.jp/article/transinf/E102.D/12/E102.D_2019MPP0005/_article/-char/ja/&hl=en",
+			"https://www.jstage.jst.go.jp/article/transinf/E102.D/12/E102.D_2019MPP0005/_article/-char/ja/", false,
+		},
+		{
+			"https://scholar.google.au/scholar_url?url=http://www.test.com&hl=1",
+			"http://www.test.com", false,
+		},
+		{ // single query (no &)
+			"http://scholar.google.au/scholar_url?url=http://www.test.com",
+			"http://www.test.com", false,
+		},
+		{ // non-latin TLD
+			"https://scholar.google.рф/scholar_url?url=http://www.test.com&hl=1",
+			"http://www.test.com", false,
 		},
 	}
 
 	for _, expected := range fixtures {
 		actualURL, err := extractPaperURL(expected.scholarURL)
-		assert.Nil(t, err)
+		if expected.toHaveErr {
+			assert.Error(t, err)
+			continue
+		}
+
+		assert.NoError(t, err)
 		assert.Equal(t, expected.URL, actualURL)
 	}
 }


### PR DESCRIPTION
Fixes #12 by more careful URL extraction.

It does not change how the aggregation works (exact match of title, url, abstract) but rather adds a simpler fix for the cause of duplication in that particular case: a scholar -> paper URL extraction was not handling different TLDs.

Now it does, and TODO is added for a possibly different aggregation that is going to be taken care of under a separate PR later.