### PR TITLE
Add JSON flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 token*.json
 credentials.json
+
+__pycache__
+.venv/
+.vscode/

--- a/gmailutils/gmail.go
+++ b/gmailutils/gmail.go
@@ -151,8 +151,8 @@ func QueryMessages(ctx context.Context, srv *gmail.Service, user, query string) 
 			messages = append(messages, msg)
 		}
 
-		bar.Finish()                                                       // defering it collides with next log
-		log.Printf("page %d: %d messaged fetched", page, len(mr.Messages)) // TODO(bzz): debug level only
+		bar.Finish() // defering it collides with next log
+		// log.Printf("page %d: %d messaged fetched", page, len(mr.Messages)) // TODO(bzz): debug level only
 		page++
 		return nil
 	})


### PR DESCRIPTION
Makes it possible to output not only Markdown/HTML but also a JSON, using `-json` flag.

It's JSONL with new paper on each line, so it's it can be piped to another tool.

It also fixes `-subj` to respect `-read` flag (same as all others).