### PR TITLE
HTML open links on a new page

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -15,7 +15,6 @@ import (
 	mrkdwn "github.com/bzz/scholar-alert-digest/markdown"
 	"github.com/bzz/scholar-alert-digest/papers"
 
-	"gitlab.com/golang-commonmark/markdown"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/gmail/v1"
@@ -149,8 +148,7 @@ func handleRoot(w http.ResponseWriter, r *http.Request) {
 	  <body>%s</body>
 	</html>
 	`
-	md := markdown.New(markdown.XHTMLOutput(true), markdown.HTML(true))
-	w.Write([]byte(fmt.Sprintf(htmlTemplText, md.RenderToString([]byte(mdBuf.String())))))
+	w.Write([]byte(fmt.Sprintf(htmlTemplText, mrkdwn.Render(mdBuf.Bytes()))))
 
 	// TODO(bzz): use html/tmeplate instead
 	// tmpl := template.Must( // render combination of the nested templates

--- a/gmailutils/token/token.go
+++ b/gmailutils/token/token.go
@@ -15,6 +15,7 @@
  */
 
 // Package token provides utilities for caching Gmail auth token.
+// TOOD(bzz) rename to auth?
 package token
 
 import (

--- a/main.go
+++ b/main.go
@@ -39,7 +39,6 @@ import (
 	mrkdwn "github.com/bzz/scholar-alert-digest/markdown"
 	"github.com/bzz/scholar-alert-digest/papers"
 
-	"gitlab.com/golang-commonmark/markdown"
 	"google.golang.org/api/gmail/v1"
 )
 
@@ -244,8 +243,7 @@ func generateAndPrintHTML(msgsCnt, titlesCnt int, unread, read map[papers.Paper]
 	var mdBuf bytes.Buffer
 	mrkdwn.GenerateMd(&mdBuf, newMdTemplText, oldMdTemplText, msgsCnt, titlesCnt, unread, read)
 
-	md := markdown.New(markdown.XHTMLOutput(true), markdown.HTML(true))
-	fmt.Printf(htmlTemplText, md.RenderToString([]byte(mdBuf.String())))
+	fmt.Printf(htmlTemplText, mrkdwn.Render(mdBuf.Bytes()))
 }
 
 func generateAndPrintMarkdown(msgsCnt, titlesCnt int, unread, read map[papers.Paper]int) {


### PR DESCRIPTION
Both, CLI and web server now always render HTML with "target=_blank" that makes browser open them in a new tab.