### PR TITLE
Experiment: show authors in Compact view

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -134,7 +134,7 @@ func handleRoot(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// aggregate
-	stats, urTitles := papers.ExtractPapersFromMsgs(urMsgs)
+	stats, urTitles := papers.ExtractPapersFromMsgs(urMsgs, true)
 	if stats.Errs != 0 {
 		log.Printf("%d errors found, extracting the papers", stats.Errs)
 	}

--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ import (
 const (
 	labelName = "[-oss-]-_ml-in-se" // "[ OSS ]/_ML-in-SE" in the Web UI
 
-	usageMessage = `usage: go run [-labels | -subj] [-html | -json] [-compact] [-mark] [-read] [-l <your-gmail-label>] [-n]
+	usageMessage = `usage: go run [-labels | -subj] [-html | -json] [-compact] [-mark] [-read] [-authors] [-l <your-gmail-label>] [-n]
 
 Polls Gmail API for unread Google Scholar alert messaged under a given label,
 aggregates by paper title and prints a list of paper URLs in Markdown format.
@@ -57,6 +57,7 @@ The -json flag will produce output in JSONL format, one paper object per line.
 The -compact flag will produce ouput report in compact format, usefull >100 papers.
 The -mark flag will mark all the aggregated emails as read in Gmail.
 The -read flag will include a new section in the report, aggregating all read emails.
+The -authors flag will include paper authors in the report.
 `
 )
 
@@ -71,6 +72,7 @@ var (
 	compact    = flag.Bool("compact", false, "output report in compact format (>100 papers)")
 	markRead   = flag.Bool("mark", false, "marks all aggregated emails as read")
 	read       = flag.Bool("read", false, "include read emails to a separate section of the report")
+	authors    = flag.Bool("authors", false, "include paper authors in the report")
 	onlySubj   = flag.Bool("subj", false, "aggregate only email subjects")
 	concurReq  = flag.Int("n", 10, "number of concurent Gmail API requests")
 )
@@ -122,7 +124,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to fetch messages from Gmail: %v", err)
 	}
-	unreadStats, unreadPapers := papers.ExtractPapersFromMsgs(urMsgs)
+	unreadStats, unreadPapers := papers.ExtractPapersFromMsgs(urMsgs, *authors)
 
 	readStats := &papers.Stats{}
 	var readPapers papers.AggPapers
@@ -131,7 +133,7 @@ func main() {
 		if err != nil {
 			log.Fatal("Failed to fetch messages from Gmail")
 		}
-		readStats, readPapers = papers.ExtractPapersFromMsgs(rMsgs)
+		readStats, readPapers = papers.ExtractPapersFromMsgs(rMsgs, *authors)
 	}
 
 	// render papers

--- a/papers/papers.go
+++ b/papers/papers.go
@@ -167,13 +167,15 @@ func extractPapersFromMsg(m *gmail.Message, inclAuthors bool) ([]Paper, error) {
 	return papers, nil
 }
 
-func extractPaperAuthor(pub string) string {
-	for i, r := range pub {
+func extractPaperAuthor(publication string) string {
+	auth := publication
+	for i, r := range publication {
 		if unicode.In(r, unicode.Dash) {
-			return strings.TrimRightFunc(pub[:i], unicode.IsSpace)
+			auth = strings.TrimRightFunc(publication[:i], unicode.IsSpace)
+			break
 		}
 	}
-	return pub
+	return strings.Title(strings.ToLower(auth))
 }
 
 // extractPaperURL returns an actual paper URL from the given scholar link.

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -58,10 +58,12 @@ var (
 ## New papers
 {{ range $paper := sortedKeys .Papers }}
  - <details onclick="document.activeElement.blur();">
-     <summary><a href="{{ .URL }}">{{ .Title }}</a> {{index $.Papers .}}</summary>
+	 <summary><a href="{{ .URL }}">{{ .Title }}</a> {{index $.Papers .}}</summary>
+	 <div class="wide"><i class="auth">{{ .Author }}</i>
      {{ if .Abstract.FirstLine -}}
-       <div class="wide">{{.Abstract.FirstLine}} {{.Abstract.Rest}}</div>
-     {{ end }}
+       <div>{{.Abstract.FirstLine}} {{.Abstract.Rest}}</div>
+	 {{ end }}
+	 </div>
    </details>
 {{ end }}
 `
@@ -86,7 +88,8 @@ var (
 	CompatStyle = `
 ul { list-style-type: none; margin: 0; padding: 0 0 0 20px; }
 #archive>ul {list-style-type: circle; }
-.wide { max-width:60%; margin-left: 1em; padding: 0.5em 0; }
+.wide { max-width:60%; margin-left: 1em; padding: 0.2em 0 0.5em 0; }
+.auth { margin-bottom: 2px; display: inline-block; }
 `
 )
 

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -42,7 +42,9 @@ var (
  - [{{ .Title }}]({{ .URL }}) ({{index $.Papers .}})
    {{- if .Abstract.FirstLine }}
    <details>
-     <summary>{{.Abstract.FirstLine}}</summary>{{.Abstract.Rest}}
+     <summary>{{.Abstract.FirstLine}}</summary>
+     <div>{{.Abstract.Rest}}</div>
+     <i>{{ .Author }}</i>
    </details>
    {{ end }}
 {{ end }}

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -61,7 +61,7 @@ var (
 {{ range $paper := sortedKeys .Papers }}
  - <details onclick="document.activeElement.blur();">
 	 <summary><a href="{{ .URL }}">{{ .Title }}</a> {{index $.Papers .}}</summary>
-	 <div class="wide"><i class="auth">{{ .Author }}</i>
+	 <div class="wide"><i>{{ .Author }}</i>
      {{ if .Abstract.FirstLine -}}
        <div>{{.Abstract.FirstLine}} {{.Abstract.Rest}}</div>
 	 {{ end }}
@@ -91,7 +91,6 @@ var (
 ul { list-style-type: none; margin: 0; padding: 0 0 0 20px; }
 #archive>ul {list-style-type: circle; }
 .wide { max-width:60%; margin-left: 1em; padding: 0.2em 0 0.5em 0; }
-.auth { margin-bottom: 2px; display: inline-block; }
 `
 )
 


### PR DESCRIPTION
It looks like this for `-compact -html`

<img width="876" alt="Screen Shot 2019-12-17 at 5 10 45 PM" src="https://user-images.githubusercontent.com/5582506/71013039-50ea6580-20f0-11ea-8cd2-75e1e4ee0b3c.png">

Can be optional e.g under `-authors`. 
But the question remains on how to show this in a regular, non-compact mode.