### PR TITLE
CLI: add -ref to link back to origin email of each paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ To include authors in the paper details snippet, use
 go run main.go -authors
 ```
 
+To include references to original email into the report, do:
+```
+go run main.go -refs
+```
+
 # Web server
 Web UI that exposes basic HTML report generation to multiple concurrent users.
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,11 @@ There is an optional more compact report template that may be useful for a big n
 go run main.go -compact
 ```
 
+To include authors in the paper details snippet, use
+```
+go run main.go -authors
+```
+
 # Web server
 Web UI that exposes basic HTML report generation to multiple concurrent users.
 

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -134,7 +134,7 @@ func handleRoot(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// aggregate
-	stats, urTitles := papers.ExtractPapersFromMsgs(urMsgs, true)
+	stats, urTitles := papers.ExtractAndAggPapersFromMsgs(urMsgs, true, true)
 	if stats.Errs != 0 {
 		log.Printf("%d errors found, extracting the papers", stats.Errs)
 	}

--- a/gmailutils/gmail.go
+++ b/gmailutils/gmail.go
@@ -221,8 +221,8 @@ func Subject(m *gmail.MessagePart) string {
 }
 
 // MessageTextBody returns the text (if any) of a given message ID
-func MessageTextBody(m *gmail.Message) ([]byte, error) {
-	body, _, err := recursiveDecodeParts(m.Payload, "text/html")
+func MessageTextBody(payload *gmail.MessagePart) ([]byte, error) {
+	body, _, err := recursiveDecodeParts(payload, "text/html")
 	if body == nil {
 		return nil, errors.New("no message payload")
 	}

--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ import (
 const (
 	labelName = "[-oss-]-_ml-in-se" // "[ OSS ]/_ML-in-SE" in the Web UI
 
-	usageMessage = `usage: go run [-labels | -subj] [-html | -json] [-compact] [-mark] [-read] [-authors] [-l <your-gmail-label>] [-n]
+	usageMessage = `usage: go run [-labels | -subj] [-html | -json] [-compact] [-mark] [-read] [-authors] [-refs] [-l <your-gmail-label>] [-n]
 
 Polls Gmail API for unread Google Scholar alert messaged under a given label,
 aggregates by paper title and prints a list of paper URLs in Markdown format.
@@ -58,6 +58,7 @@ The -compact flag will produce ouput report in compact format, usefull >100 pape
 The -mark flag will mark all the aggregated emails as read in Gmail.
 The -read flag will include a new section in the report, aggregating all read emails.
 The -authors flag will include paper authors in the report.
+The -refs flag will add links to all email messages that mention each paper.
 `
 )
 

--- a/main.go
+++ b/main.go
@@ -73,6 +73,7 @@ var (
 	markRead   = flag.Bool("mark", false, "marks all aggregated emails as read")
 	read       = flag.Bool("read", false, "include read emails to a separate section of the report")
 	authors    = flag.Bool("authors", false, "include paper authors in the report")
+	refs       = flag.Bool("refs", false, "include orignin references to Gmail messages in report")
 	onlySubj   = flag.Bool("subj", false, "aggregate only email subjects")
 	concurReq  = flag.Int("n", 10, "number of concurent Gmail API requests")
 )
@@ -124,7 +125,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to fetch messages from Gmail: %v", err)
 	}
-	unreadStats, unreadPapers := papers.ExtractPapersFromMsgs(urMsgs, *authors)
+	unreadStats, unreadPapers := papers.ExtractAndAggPapersFromMsgs(urMsgs, *authors, *refs)
 
 	readStats := &papers.Stats{}
 	var readPapers papers.AggPapers
@@ -133,7 +134,7 @@ func main() {
 		if err != nil {
 			log.Fatal("Failed to fetch messages from Gmail")
 		}
-		readStats, readPapers = papers.ExtractPapersFromMsgs(rMsgs, *authors)
+		readStats, readPapers = papers.ExtractAndAggPapersFromMsgs(rMsgs, *authors, *refs)
 	}
 
 	// render papers
@@ -143,6 +144,7 @@ func main() {
 		template, style = templates.CompactMdTemplText, templates.CompatStyle
 	}
 
+	log.Printf("rendering %d papers", len(unreadPapers)+len(readPapers))
 	if *outputJSON {
 		r = templates.NewJSONRenderer()
 	} else if *outputHTML {

--- a/papers/papers.go
+++ b/papers/papers.go
@@ -26,8 +26,9 @@ type Paper struct {
 	URL      string
 	Author   string `json:",omitempty"`
 	Abstract Abstract
-	Refs     []string `json:",omitempty"`
-	Freq     int
+	// TODO(bzz): add Ref.Title and Ref.ID
+	Refs []string `json:",omitempty"`
+	Freq int
 }
 
 // Abstract represents a view of the parsed abstract.

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -69,12 +69,13 @@ var (
 
 ## New papers
 {{ range $title := sortedKeys .Papers }}
+   {{ $paper := index $.Papers . }}
  - <details onclick="document.activeElement.blur();">
-	 <summary><a href="{{ .URL }}">{{ .Title }}</a> {{index $.Papers .}}</summary>
-	 <div class="wide"><i>{{ .Author }}</i>
-     {{ if .Abstract.FirstLine -}}
-       <div>{{.Abstract.FirstLine}} {{.Abstract.Rest}}</div>
-	 {{ end }}
+	 <summary><a href="{{ $paper.URL }}">{{ $paper.Title }}</a> ({{$paper.Freq}})</summary>
+	 <div class="wide"><i>{{ $paper.Author }}</i>
+     {{- if $paper.Abstract.FirstLine }}
+	   <div>{{$paper.Abstract.FirstLine}} {{$paper.Abstract.Rest}}</div>
+	 {{- end }}
 	 </div>
    </details>
 {{ end }}

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -177,8 +177,7 @@ func (r *MarkdownRenderer) newMdReport(out io.Writer, st *papers.Stats, agrPaper
 		UnreadEmails int
 		TotalPapers  int
 		UniqPapers   int
-		// add MsgURLPrefix https://mail.google.com/mail/#inbox/<messageId>
-		Papers papers.AggPapers
+		Papers       papers.AggPapers
 	}{
 		time.Now().Format(time.RFC3339),
 		st.Msgs,


### PR DESCRIPTION
TODOs:
 - [x] refactor paper aggregation by Title
 - [x] change normal Md templates to show refs
 - [x] update `-compact`to work with new aggregation
 - [x] add `-refs` to `-compact` mode (extract "refs" to top-level template and `.Clone()` it in both, Md and Compact)

<img width="907" alt="Screen Shot of report with references" src="https://user-images.githubusercontent.com/5582506/71191788-6776f500-2287-11ea-9c75-d43751c8661a.png">

This is the same state as in https://github.com/bzz/scholar-alert-digest/issues/13#issuecomment-567569189. 

Further work on showing the titles instead of numbers, as suggested in https://github.com/bzz/scholar-alert-digest/issues/13#issuecomment-568209701, is going to be done in a separate subsequent PR.