### PR TITLE
Authors: change template, include names above the fold

### DIFF
--- a/templates/templates.go
+++ b/templates/templates.go
@@ -41,12 +41,11 @@ var (
 ## New papers
 {{ range $title := sortedKeys .Papers }}
    {{ $paper := index $.Papers . }}
- - [{{ $paper.Title }}]({{ $paper.URL }}) {{ template "refs" $paper }}
+ - [{{ $paper.Title }}]({{ $paper.URL }}){{if $paper.Author}}, <i>{{ $paper.Author }}</i>{{end}} {{ template "refs" $paper }}
    {{- if $paper.Abstract.FirstLine }}
    <details>
      <summary>{{ $paper.Abstract.FirstLine }}</summary>
      <div>{{ $paper.Abstract.Rest }}</div>
-     {{if $paper.Author}}<i>{{ $paper.Author }}</i>{{end}}
    </details>
    {{ end }}
 {{ end }}
@@ -73,8 +72,8 @@ var (
 {{ range $title := sortedKeys .Papers }}
    {{ $paper := index $.Papers . }}
  - <details onclick="document.activeElement.blur();">
-	 <summary><a href="{{ $paper.URL }}">{{ $paper.Title }}</a> {{ template "refs" $paper }}</summary>
-	 <div class="wide"><i>{{ $paper.Author }}</i>
+	 <summary><a href="{{ $paper.URL }}">{{ $paper.Title }}</a>, <i>{{ $paper.Author }}</i> {{ template "refs" $paper }}</summary>
+	 <div class="wide">
      {{- if $paper.Abstract.FirstLine }}
 	   <div>{{$paper.Abstract.FirstLine}} {{$paper.Abstract.Rest}}</div>
 	 {{- end }}


### PR DESCRIPTION
Addresses #29 

New templates (`-authors -refs`) look like this:

## Normal
<img width="949" alt="Screen Shot 2019-12-24 at 12 35 43 AM" src="https://user-images.githubusercontent.com/5582506/71385098-ac7f8c00-25e5-11ea-8aa6-173048695654.png">

## Compact
<img width="1204" alt="Screen Shot 2019-12-24 at 12 35 26 AM" src="https://user-images.githubusercontent.com/5582506/71385108-b608f400-25e5-11ea-94af-f3991c242371.png">


IMO it does a bit of the mess in the `-compact` but I have no ideas how to improve that yet 🤷‍♂ so all LGTM.

@jzuken let me know what you think!