### PR TITLE
subj: improve RU locale handling

### DIFF
--- a/gmailutils/gmail.go
+++ b/gmailutils/gmail.go
@@ -231,38 +231,38 @@ func NormalizeAndSplit(subj string) []string {
 	return srcType
 }
 
-type subjFormat struct{ ru, en string }
+type subjFormat struct{ ru, En string }
+
+var (
+	citations = subjFormat{
+		": новые ссылки", "new citations",
+	}
+	related = subjFormat{
+		"Новые статьи, связанные с работами автора ", "new related research",
+	}
+	search = subjFormat{
+		"Новые результаты по запросу ", "new results",
+	}
+	articles = subjFormat{
+		"Новые статьи пользователя ", "new articles",
+	}
+)
 
 // splitOnRuLocale normalizes subj from RU locale.
 func splitOnRuLocale(s string) []string {
-	var (
-		result []string
-
-		citations = subjFormat{
-			": новые ссылки", "new citations",
-		}
-		related = subjFormat{
-			"Новые статьи, связанные с работами автора ", "new related research",
-		}
-		query = subjFormat{
-			"Новые результаты по запросу ", "new results",
-		}
-		articles = subjFormat{
-			"Новые статьи пользователя ", "new articles",
-		}
-	)
+	var result []string
 
 	switch {
 	case strings.HasSuffix(s, citations.ru):
-		result = []string{s[:strings.Index(s, citations.ru)], citations.en}
+		result = []string{s[:strings.Index(s, citations.ru)], citations.En}
 	case s == "Новые ссылки на мои статьи":
-		result = []string{"me", citations.en}
+		result = []string{"me", citations.En}
 	case strings.HasPrefix(s, related.ru):
-		result = []string{s[strings.Index(s, related.ru):], related.en}
-	case strings.HasPrefix(s, query.ru):
-		result = []string{s[strings.Index(s, query.ru):], query.en}
+		result = []string{s[len(related.ru):], related.En}
+	case strings.HasPrefix(s, search.ru):
+		result = []string{s[len(search.ru):], search.En}
 	case strings.HasPrefix(s, articles.ru):
-		result = []string{s[strings.Index(s, articles.ru):], articles.en}
+		result = []string{s[len(articles.ru):], articles.En}
 	}
 
 	return result

--- a/gmailutils/gmail.go
+++ b/gmailutils/gmail.go
@@ -246,6 +246,10 @@ var (
 	articles = subjFormat{
 		"Новые статьи пользователя ", "new articles",
 	}
+	// TODO(bzz): add this as well
+	// recomended = subjFormat{
+	// 	"Рекомендуемые статьи", "?????????",
+	// }
 )
 
 // splitOnRuLocale normalizes subj from RU locale.

--- a/gmailutils/gmail_test.go
+++ b/gmailutils/gmail_test.go
@@ -31,6 +31,9 @@ func TestSubjSplit(t *testing.T) {
 			`Новые результаты по запросу "deep learning source code"`,
 			`"deep learning source code"`, search.En,
 		},
+		// {
+		// 	`Рекомендуемые статьи`, "", recomended.En
+		// }
 	}
 
 	for _, f := range fixtures {

--- a/gmailutils/gmail_test.go
+++ b/gmailutils/gmail_test.go
@@ -1,19 +1,43 @@
 package gmailutils
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSubjSplit(t *testing.T) {
-	subjs := []string{
-		`Новые статьи, связанные с работами автора Mohamed ...`,
-		`"Learning to represent programs with graphs" - new citations`,
-		`"machine learning on code" – de nouveaux résultats sont disponibles`,
+	fixtures := []struct {
+		subj       string
+		src, typee string
+	}{
+		{
+			`Новые статьи, связанные с работами автора Mohamed ...`,
+			"Mohamed ...", related.En,
+		},
+		{
+			`"Learning to represent programs with graphs" - new citations`,
+			`"Learning to represent programs with graphs"`, citations.En,
+		},
+		{
+			`"machine learning on code" – de nouveaux résultats sont disponibles`,
+			`"machine learning on code"`, "de nouveaux résultats sont disponibles", // TODO(bzz): normalize FR so it's search.En here
+		},
+		{
+			`Новые статьи пользователя Diomidis Spinellis`,
+			"Diomidis Spinellis", articles.En,
+		},
+		{
+			`Новые результаты по запросу "deep learning source code"`,
+			`"deep learning source code"`, search.En,
+		},
 	}
 
-	for _, s := range subjs {
-		srcType := NormalizeAndSplit(s)
-		assert.Equal(t, 2, len(srcType), "%q parsing failed, restult: %+v", s, srcType)
+	for _, f := range fixtures {
+		srcType := NormalizeAndSplit(f.subj)
+		assert.Equal(t, 2, len(srcType), "%q parsing failed, restult: %+v", f.subj, srcType)
+
+		assert.Equal(t, f.src, srcType[0])
+		assert.Equal(t, f.typee, srcType[1])
 	}
 }

--- a/gmailutils/gmail_test.go
+++ b/gmailutils/gmail_test.go
@@ -1,0 +1,19 @@
+package gmailutils
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestSubjSplit(t *testing.T) {
+	subjs := []string{
+		`Новые статьи, связанные с работами автора Mohamed ...`,
+		`"Learning to represent programs with graphs" - new citations`,
+		`"machine learning on code" – de nouveaux résultats sont disponibles`,
+	}
+
+	for _, s := range subjs {
+		srcType := NormalizeAndSplit(s)
+		assert.Equal(t, 2, len(srcType), "%q parsing failed, restult: %+v", s, srcType)
+	}
+}


### PR DESCRIPTION
To move forward #13 this updates `-subj` to:
 - only read scholar emails (`from:scholaralerts-noreply` gmail search)
 - handle RU locale (on top of EN and FR that are already handled)

@jzuken could you please give this a try and share a new gist \w results of:

```
time go run main.go -subj
time go run main.go -subj | uniq -c | sort -dr
```