### PR TITLE
Use author names in refs, when available

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -47,24 +47,6 @@ var ( // templates
 </form>
 {{ end }}
 `
-
-	newMdTemplText = `# Google Scholar Alert Digest
-
-**Date**: {{.Date}}
-**Unread emails**: {{.UnreadEmails}}
-**Paper titles**: {{.TotalPapers}}
-**Uniq paper titles**: {{.UniqPapers}}
-
-## New papers
-{{ range $paper := sortedKeys .Papers }}
- - [{{ .Title }}]({{ .URL }}) ({{index $.Papers .}})
-   {{- if .Abstract.FirstLine }}
-   <details>
-     <summary>{{.Abstract.FirstLine}}</summary>{{.Abstract.Rest}}
-   </details>
-   {{ end }}
-{{ end }}
-`
 )
 
 var ( // configuration

--- a/gmailutils/gmail.go
+++ b/gmailutils/gmail.go
@@ -263,6 +263,9 @@ func NormalizeAndSplit(subj string) []string {
 type subjFormat struct{ ru, En string }
 
 var (
+	articles = subjFormat{
+		"Новые статьи пользователя ", "new articles",
+	}
 	citations = subjFormat{
 		": новые ссылки", "new citations",
 	}
@@ -271,9 +274,6 @@ var (
 	}
 	search = subjFormat{
 		"Новые результаты по запросу ", "new results",
-	}
-	articles = subjFormat{
-		"Новые статьи пользователя ", "new articles",
 	}
 	// TODO(bzz): add this as well
 	// recomended = subjFormat{

--- a/papers/papers.go
+++ b/papers/papers.go
@@ -173,7 +173,14 @@ func extractPapersFromMsg(m *gmail.Message, inclAuthors bool) ([]*Paper, error) 
 
 		mSrc := ""
 		if srcType := gmailutils.NormalizeAndSplit(subj); len(srcType) == 2 {
-			mSrc = srcType[0]
+			// FIXME(bzz): this is a hack, replace it by switch over
+			// some exported types e.g gmailutils.Citations
+			if (strings.Index(srcType[1], "articles") > 0 ||
+				strings.Index(srcType[1], "citations") > 0 ||
+				strings.Index(srcType[1], "research") > 0) &&
+				strings.Index(srcType[0], `"`) == -1 {
+				mSrc = srcType[0]
+			}
 		}
 
 		papers = append(papers,

--- a/papers/papers.go
+++ b/papers/papers.go
@@ -26,9 +26,13 @@ type Paper struct {
 	URL      string
 	Author   string `json:",omitempty"`
 	Abstract Abstract
-	// TODO(bzz): add Ref.Title and Ref.ID
-	Refs []string `json:",omitempty"`
-	Freq int
+	Refs     []Ref `json:",omitempty"`
+	Freq     int
+}
+
+// Ref saves information about a source, referencing the paper.
+type Ref struct {
+	ID, Title string
 }
 
 // Abstract represents a view of the parsed abstract.
@@ -165,11 +169,17 @@ func extractPapersFromMsg(m *gmail.Message, inclAuthors bool) ([]*Paper, error) 
 
 		N, lookahead := 80, 10 // max number of runes to process
 		first, rest := separateFirstLine(abstract, N, lookahead)
+		abs := Abstract{first, rest}
+
+		mSrc := ""
+		if srcType := gmailutils.NormalizeAndSplit(subj); len(srcType) == 2 {
+			mSrc = srcType[0]
+		}
+
 		papers = append(papers,
 			&Paper{
-				title, url, author,
-				Abstract{first, rest},
-				[]string{m.Id},
+				title, url, author, abs,
+				[]Ref{Ref{m.Id, mSrc}},
 				1,
 			})
 	}

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -53,12 +53,12 @@ var (
 	refsMdTemplateText = `
 {{ define "refs" -}}
 ({{ if eq (len .Refs) 0}}{{ .Freq }}{{end}}
-{{- if gt (len .Refs) 1 }}{{ .Freq }}: {{ end }}
-{{- range $i, $ID := .Refs}}
+{{- if gt (len .Refs) 1}}{{ .Freq }}: {{end}}
+{{- range $i, $ref := .Refs}}
 	{{- if $i}}, {{end}}
-	{{- anchorHTML $ID "" $i -}}
+	{{- anchorHTML $ref.ID $ref.Title $i -}}
 {{- end}})
-{{- end }}
+{{- end}}
 `
 
 	CompactMdTemplText = `# Google Scholar Alert Digest

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -194,7 +194,7 @@ func NewMarkdownRenderer(templateText, oldTemplateText string) Renderer {
 				//  * html/template escape HTML strings \wo template.HTML
 				return template.HTML(
 					fmt.Sprintf(
-						"<a target='_blank' href='https://mail.google.com/mail/#inbox/%s'>%s</a>",
+						"<a target='_blank' style='color: inherit; text-decoration: none;' href='https://mail.google.com/mail/#inbox/%s'>%s</a>",
 						ID, title,
 					),
 				)


### PR DESCRIPTION
This addresses #13 in a way, discussed under https://github.com/bzz/scholar-alert-digest/issues/13#issuecomment-569050242

TODOs:
 - [x] only show names
 - [ ] ~sort refs: names first, then numbers for the rest~
 - [ ] ~make sure the order of refs is the same (`-compact` or not)~
 - [ ] ~reactor filtering logic to `switch` instead of `strings.Index() > 0`~

<img width="1324" alt="Screen Shot 2019-12-31 at 9 15 52 PM" src="https://user-images.githubusercontent.com/5582506/71633170-ecacc300-2c12-11ea-8ffd-a81cdf836c96.png">
