### PR TITLE
Server: optional JSON renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ go run main.go -refs
 ```
 
 # Web server
-Web UI that exposes basic HTML report generation to multiple concurrent users.
+The Web UI exposes HTML report generation to multiple concurrent users.
 
 ## Configure
 It does not support the same OAuth client credentials as CLI from `credentials.json`.
@@ -111,7 +111,7 @@ The report generation is exposed though a web server that can be started with
 go run ./cmd/server [-compact]
 ```
 
-to spin up a server on http://localhost:8080
+to spin up a server at http://localhost:8080
 
 Start by visiting http://localhost:8080/login to get the user OAuth access token.
 Visit http://localhost:8080/labels to chose your label name.

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -78,7 +78,10 @@ var ( // CLI
 	// TODO(bzz): add -read support + equivalent per-user config option (cookies)
 )
 
-var htmlRn templates.Renderer
+var (
+	htmlRn templates.Renderer
+	jsonRn templates.Renderer
+)
 
 func main() {
 	flag.Parse()
@@ -88,6 +91,7 @@ func main() {
 		templateText, style = templates.CompactMdTemplText, templates.CompatStyle
 	}
 	htmlRn = templates.NewHTMLRenderer(templateText, style)
+	jsonRn = templates.NewJSONRenderer()
 
 	// TODO(bzz):
 	//  - configure the log level, to include requests in debug
@@ -140,7 +144,12 @@ func handleRoot(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// render
-	htmlRn.Render(w, stats, urTitles, nil)
+	if _, ok := r.URL.Query()["json"]; ok {
+		w.Header().Set("Content-Type", "application/json")
+		jsonRn.Render(w, stats, urTitles, nil)
+	} else {
+		htmlRn.Render(w, stats, urTitles, nil)
+	}
 }
 
 func handleLabels(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Adding query string `?json` to the `/` route will render the output in JSON instead of HTML, in the same format as `go run main.go -json` does.

This is a first step towards more interactive web frontend.