### PR TITLE
Adjust scholarURLPrefix regex to match .co.uk scholar urls

### DIFF
--- a/papers/papers.go
+++ b/papers/papers.go
@@ -18,7 +18,7 @@ import (
 	"github.com/bzz/scholar-alert-digest/gmailutils"
 )
 
-var scholarURLPrefix = regexp.MustCompile(`http(s)?://scholar\.google\.\p{L}+/scholar_url\?url=`)
+var scholarURLPrefix = regexp.MustCompile(`http(s)?://scholar\.google\.\p{L}+(\.\p{L}+)?/scholar_url\?url=`)
 
 // Paper is a map key, thus aggregation take into account all it's fields.
 type Paper struct {


### PR DESCRIPTION
If the emails use `http://scholar.google.co.uk/scholar_url?url=....`
then because the url has `.co.uk` rather than `.com` the regex doesn't
match the url and hence ignores the paper. This adjusted url fixes it to
match any `.com` and `.co.uk` (and theoretically any other one or
two-part suffix).

fixes #49 