### PR TITLE
frontend: add button to download hidden papers metadata

### DIFF
--- a/frontend/src/components/Download.js
+++ b/frontend/src/components/Download.js
@@ -1,0 +1,35 @@
+import React from "react"
+import PropTypes from "prop-types"
+import Switch from "./Switch"
+
+import "components/components.css"
+
+const Download = ({label, filetype, filename, content, disabled = false}) => {
+  if (disabled) {
+    return (
+      <Switch label={label} disabled />
+    )
+  }
+
+  const dataURI = `data:${filetype};base64,${content}`
+
+  return (
+    <a className="clickable-label clickable-label--link" download={filename} href={dataURI}>
+      {label}
+    </a>
+  )
+}
+
+Download.defaultProps = {
+  disabled: false,
+}
+
+Download.propTypes = {
+  disabled: PropTypes.bool,
+  label: PropTypes.string.isRequired,
+  filetype: PropTypes.string.isRequired,
+  filename: PropTypes.string.isRequired,
+  content: PropTypes.string.isRequired,
+}
+
+export default Download

--- a/frontend/src/components/Switch.js
+++ b/frontend/src/components/Switch.js
@@ -4,7 +4,7 @@ import PropTypes from "prop-types"
 import "components/components.css"
 
 const Switch = ({label, onClick, disabled = false}) => (
-  <button className="switch" type="button" onClick={onClick} disabled={disabled}>
+  <button className="clickable-label" type="button" onClick={onClick} disabled={disabled}>
     {label}
   </button>
 )

--- a/frontend/src/components/components.css
+++ b/frontend/src/components/components.css
@@ -21,7 +21,7 @@
 }
 
 /********** Switch **********/
-.switch {
+.clickable-label {
   cursor: pointer;
   font-size: 1rem;
   display: inline;
@@ -37,8 +37,8 @@
   padding: 0;
 }
 
-.switch:hover,
-.switch:focus {
+.clickable-label:hover,
+.clickable-label:focus {
   outline: none;
 }
 

--- a/frontend/src/components/components.css
+++ b/frontend/src/components/components.css
@@ -42,6 +42,18 @@
   outline: none;
 }
 
+.clickable-label--link {
+  color: unset !important;
+  font-weight: normal;
+}
+
+.clickable-label--link:hover {
+  text-decoration: none !important;
+}
+
+.clickable-label--disabled {
+  color: #6e6e6e !important;
+}
 /********** Loader **********/
 /* taken from https://codepen.io/megatroncoder/pen/Xqeyva?editors=0100 */
 


### PR DESCRIPTION
Based on this [request](https://github.com/bzz/scholar-alert-digest/pull/52#issuecomment-803172060)

This PR adds a clickable label "download selected" in the report header visible when all papers are shown. Clicking on it prompts to save a json file with the hidden papers metadata.

My main consideration for UX / UI here was simplicity of implementation. Open for further discussion.

![download-button](https://user-images.githubusercontent.com/5688346/139524717-db600e30-0589-4807-adea-6f6f7d50f049.png)
